### PR TITLE
Fix simulation to allow a dict for dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2024-12-06 14:02:41
+
+### Fixed
+
+- Household simulation example broken due to a type error.
+
 ## [2.2.1] - 2024-12-03 13:16:27
 
 ### Fixed
@@ -45,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[2.2.2]: https://github.com/PolicyEngine/policyengine.py/compare/2.2.1...2.2.2
 [2.2.1]: https://github.com/PolicyEngine/policyengine.py/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/PolicyEngine/policyengine.py/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/PolicyEngine/policyengine.py/compare/2.0.0...2.1.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -31,3 +31,8 @@
     fixed:
     - Formatting in constituency charts.
   date: 2024-12-03 13:16:27
+- bump: patch
+  changes:
+    fixed:
+    - Household simulation example broken due to a type error.
+  date: 2024-12-06 14:02:41

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,0 @@
-- bump: patch
-  changes:
-    fixed:
-      - Household simulation example broken due to a type error.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Household simulation example broken due to a type error.

--- a/policyengine/simulation.py
+++ b/policyengine/simulation.py
@@ -91,6 +91,10 @@ class Simulation:
         self._initialise_simulations()
 
     def _set_dataset(self, dataset: str):
+        if isinstance(dataset, dict):
+            self.data = dataset
+            return
+
         if dataset in DATASETS[self.country]:
             self.data = DATASETS[self.country][dataset]
         elif dataset is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine"
-version = "2.2.1"
+version = "2.2.2"
 description = "A package to conduct policy analysis using PolicyEngine tax-benefit models."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
fixes #53

in the example from index.ipnyb we use dataset as a dict for household cacluations.

In the code we were failing to correctly handle this case.

This happening, in part, because the type hint was wrong, but since most of the type hints are wrong I'm fixing the bug first and will come back to address the type hints.