### PR TITLE
Create parameter serializer and convert Infinity and -Infinity to np.inf and -np.inf

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Refactored ParametricReform schema into clearer subschemas.
+    - Added conversion of Infinity and -Infinity to np.inf and -np.inf.

--- a/policyengine/simulation.py
+++ b/policyengine/simulation.py
@@ -195,7 +195,6 @@ class Simulation:
         }[country][macro]
 
         if isinstance(reform, ParametricReform):
-            print("Dumping reform model")
             reform = reform.model_dump()
 
         simulation: CountrySimulation = _simulation_type(

--- a/policyengine/simulation.py
+++ b/policyengine/simulation.py
@@ -195,6 +195,7 @@ class Simulation:
         }[country][macro]
 
         if isinstance(reform, ParametricReform):
+            print("Dumping reform model")
             reform = reform.model_dump()
 
         simulation: CountrySimulation = _simulation_type(

--- a/policyengine/utils/reforms.py
+++ b/policyengine/utils/reforms.py
@@ -1,13 +1,45 @@
 import re
-from pydantic import RootModel, ValidationError, Field, model_validator
-from typing import Dict, TYPE_CHECKING
-from annotated_types import Ge, Le
+from pydantic import (
+    RootModel,
+    ValidationError,
+    Field,
+    model_validator,
+    field_validator,
+)
+from typing import Dict, Self, Any, TYPE_CHECKING
 from typing_extensions import Annotated
 from typing import Callable
 from policyengine_core.simulations import Simulation
 
 
+class ParameterChangeDict(RootModel):
+    """A dict of changes to a parameter, with custom date string as keys
+    and various possible value types."""
+
+    root: Dict[str, Any]
+
+    @model_validator(mode="after")
+    def check_keys(self) -> Self:
+        for key in self.root.keys():
+            # Check if key is YYYY-MM-DD.YYYY-MM-DD
+            if not re.match(r"^\d{4}-\d{2}-\d{2}\.\d{4}-\d{2}-\d{2}$", key):
+                raise ValueError(f"Invalid date format in key: {key}")
+        return self
+
+    # Convert "Infinity" to "np.inf" and "-Infinity" to "-np.inf"
+    @field_validator("root", mode="after")
+    @classmethod
+    def convert_infinity(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        for key, val in value.items():
+            if isinstance(val, str):
+                if val == "Infinity":
+                    value[key] = float("inf")
+                elif val == "-Infinity":
+                    value[key] = float("-inf")
+        return value
+
+
 class ParametricReform(RootModel):
     """A reform that just changes parameter values."""
 
-    root: Dict[str, Dict | float | bool]
+    root: Dict[str, ParameterChangeDict]

--- a/policyengine/utils/reforms.py
+++ b/policyengine/utils/reforms.py
@@ -1,3 +1,4 @@
+import re
 from pydantic import (
     RootModel,
     field_validator,
@@ -56,8 +57,8 @@ class ParameterChangeDict(RootModel):
         date_range_keys_re = r"^\d{4}-\d{2}-\d{2}\.\d{4}-\d{2}-\d{2}$"
 
         for key in value.keys():
-            if not year_keys_re.match(key) and not date_range_keys_re.match(
-                key
+            if not re.match(year_keys_re, key) and not re.match(
+                date_range_keys_re, key
             ):
                 raise ValueError(
                     f"Key '{key}' must be a single year (YYYY) or a date range (YYYY-MM-DD.YYYY-MM-DD)"

--- a/policyengine/utils/reforms.py
+++ b/policyengine/utils/reforms.py
@@ -1,45 +1,81 @@
-import re
 from pydantic import (
     RootModel,
-    ValidationError,
     Field,
-    model_validator,
     field_validator,
 )
-from typing import Dict, Self, Any, TYPE_CHECKING
+from typing import Dict, Any
 from typing_extensions import Annotated
-from typing import Callable
 from policyengine_core.simulations import Simulation
 
 
-class ParameterChangeDict(RootModel):
-    """A dict of changes to a parameter, with custom date string as keys
-    and various possible value types."""
+class ParameterChangeValue(RootModel):
+    """A value for a parameter change, which can be any primitive type or 'Infinity'/'-Infinity'"""
 
-    root: Dict[str, Any]
+    # To prevent validation errors, allow all types except containers
+    # via field validator
+    root: Any
 
-    @model_validator(mode="after")
-    def check_keys(self) -> Self:
-        for key in self.root.keys():
-            # Check if key is YYYY-MM-DD.YYYY-MM-DD
-            if not re.match(r"^\d{4}-\d{2}-\d{2}\.\d{4}-\d{2}-\d{2}$", key):
-                raise ValueError(f"Invalid date format in key: {key}")
-        return self
+    @field_validator("root", mode="after")
+    @classmethod
+    def check_type(cls, value: Any) -> Any:
+        # Check if the value is not a container type
+        if isinstance(value, (dict, list, set, tuple)):
+            raise ValueError(
+                "ParameterChangeValue must not be a container type (dict, list, set, tuple)"
+            )
+        return value
 
     # Convert "Infinity" to "np.inf" and "-Infinity" to "-np.inf"
     @field_validator("root", mode="after")
     @classmethod
-    def convert_infinity(cls, value: Dict[str, Any]) -> Dict[str, Any]:
-        for key, val in value.items():
-            if isinstance(val, str):
-                if val == "Infinity":
-                    value[key] = float("inf")
-                elif val == "-Infinity":
-                    value[key] = float("-inf")
+    def convert_infinity(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            if value == "Infinity":
+                value = float("inf")
+            elif value == "-Infinity":
+                value = float("-inf")
         return value
 
 
-class ParametricReform(RootModel):
-    """A reform that just changes parameter values."""
+class ParameterChangePeriod(RootModel):
+    """A period for a parameter change, which can be a single year or a date range"""
 
-    root: Dict[str, ParameterChangeDict]
+    root: Annotated[
+        str,
+        Field(
+            pattern=r"^\d{4}$|^\d{4}-\d{2}-\d{2}\.\d{4}-\d{2}-\d{2}$",
+            description="A single year (YYYY) or a date range (YYYY-MM-DD.YYYY-MM-DD)",
+        ),
+    ]
+
+    def __hash__(self):
+        return hash(self.root)
+
+    def __eq__(self, other):
+        if isinstance(other, ParameterChangePeriod):
+            return self.root == other.root
+        return False
+
+
+class ParameterChangeDict(RootModel):
+    """
+    A dict of changes to a parameter, with custom date string as keys
+    and various possible value types.
+
+    Keys can be formatted one of two ways:
+    1. A single year (e.g., "YYYY")
+    2. A date range (e.g., "YYYY-MM-DD.YYYY-MM-DD")
+    """
+
+    root: Dict[ParameterChangePeriod, ParameterChangeValue]
+
+
+class ParametricReform(RootModel):
+    """
+    A reform that just changes parameter values.
+
+    This is a dict that equates a parameter name to either a single value or a dict of changes.
+
+    """
+
+    root: Dict[str, ParameterChangeValue | ParameterChangeDict]

--- a/tests/utils/test_reforms.py
+++ b/tests/utils/test_reforms.py
@@ -1,0 +1,115 @@
+from pydantic import ValidationError
+import pytest
+import numpy as np
+
+from policyengine.utils.reforms import ParameterChangeDict, ParametricReform
+
+
+class TestParameterChangeDict:
+    def test_schema__given_float_inputs__returns_valid_dict(self):
+        input_data = {
+            "2023-01-01.2023-12-31": 0.1,
+            "2024-01-01.2024-12-31": 0.2,
+        }
+
+        result = ParameterChangeDict(root=input_data)
+
+        assert isinstance(result, ParameterChangeDict)
+        assert result.root == input_data
+
+    def test_schema__given_string_inputs__returns_valid_dict(self):
+        input_data = {
+            "2023-01-01.2023-12-31": "0.1",
+            "2024-01-01.2024-12-31": "0.2",
+        }
+
+        result = ParameterChangeDict(root=input_data)
+
+        assert isinstance(result, ParameterChangeDict)
+        assert result.root == input_data
+
+    def test_schema__given_infinity_string__returns_valid_dict(self):
+        input_data = {
+            "2023-01-01.2023-12-31": "Infinity",
+            "2024-01-01.2024-12-31": "-Infinity",
+        }
+
+        result = ParameterChangeDict(root=input_data)
+
+        assert isinstance(result, ParameterChangeDict)
+        assert result.root == {
+            "2023-01-01.2023-12-31": np.inf,
+            "2024-01-01.2024-12-31": -np.inf,
+        }
+
+    def test_schema__given_invalid_date_format__raises_validation_error(self):
+        input_data = {"2023-01-01.2023-12-31": 0.1, "invalid_date_format": 0.2}
+
+        with pytest.raises(
+            ValidationError, match="Invalid date format in key"
+        ):
+            ParameterChangeDict(root=input_data)
+
+    def test_schema__given_invalid_key_type__raises_validation_error(self):
+        input_data = {123: 0.1, "2024-01-01.2024-12-31": 0.2}
+
+        with pytest.raises(
+            ValidationError, match="validation error for ParameterChangeDict"
+        ):
+            ParameterChangeDict(root=input_data)
+
+
+class TestParametricReform:
+    def test_schema__given_valid_dict__returns_valid_reform(self):
+        input_data = {
+            "parameter1": {
+                "2023-01-01.2023-12-31": 0.1,
+                "2024-01-01.2024-12-31": 0.2,
+            },
+            "parameter2": {
+                "2023-01-01.2023-12-31": 0.3,
+                "2024-01-01.2024-12-31": 0.4,
+            },
+        }
+
+        expected_output_data = {
+            "parameter1": ParameterChangeDict(
+                root={
+                    "2023-01-01.2023-12-31": 0.1,
+                    "2024-01-01.2024-12-31": 0.2,
+                }
+            ),
+            "parameter2": ParameterChangeDict(
+                root={
+                    "2023-01-01.2023-12-31": 0.3,
+                    "2024-01-01.2024-12-31": 0.4,
+                }
+            ),
+        }
+
+        result = ParametricReform(root=input_data)
+
+        assert isinstance(result, ParametricReform)
+        assert result.root == expected_output_data
+
+    def test_schema__given_invalid_key_type__raises_validation_error(self):
+        input_data = {
+            123: {"2023-01-01.2023-12-31": 0.1, "2024-01-01.2024-12-31": 0.2},
+            "valid_parameter": {
+                "2023-01-01.2023-12-31": 0.3,
+                "2024-01-01.2024-12-31": 0.4,
+            },
+        }
+
+        with pytest.raises(
+            ValidationError, match=r"validation errors? for ParametricReform"
+        ):
+            ParametricReform(root=input_data)
+
+    def test_schema__given_dateless_structure__raises_validation_error(self):
+        input_data = {"parameter1": 0.1, "parameter2": 0.2}
+
+        with pytest.raises(
+            ValidationError, match=r"validation errors? for ParametricReform"
+        ):
+            ParametricReform(root=input_data)

--- a/tests/utils/test_reforms.py
+++ b/tests/utils/test_reforms.py
@@ -18,12 +18,8 @@ class TestParameterChangeDict:
         }
 
         expected_output_data = {
-            ParameterChangePeriod(
-                root="2023-01-01.2023-12-31"
-            ): ParameterChangeValue(root=0.1),
-            ParameterChangePeriod(
-                root="2024-01-01.2024-12-31"
-            ): ParameterChangeValue(root=0.2),
+            "2023-01-01.2023-12-31": ParameterChangeValue(root=0.1),
+            "2024-01-01.2024-12-31": ParameterChangeValue(root=0.2),
         }
 
         result = ParameterChangeDict(root=input_data)
@@ -38,12 +34,8 @@ class TestParameterChangeDict:
         }
 
         expected_output_data = {
-            ParameterChangePeriod(
-                root="2023-01-01.2023-12-31"
-            ): ParameterChangeValue(root="0.1"),
-            ParameterChangePeriod(
-                root="2024-01-01.2024-12-31"
-            ): ParameterChangeValue(root="0.2"),
+            "2023-01-01.2023-12-31": ParameterChangeValue(root="0.1"),
+            "2024-01-01.2024-12-31": ParameterChangeValue(root="0.2"),
         }
 
         result = ParameterChangeDict(root=input_data)
@@ -58,12 +50,8 @@ class TestParameterChangeDict:
         }
 
         expected_output_data = {
-            ParameterChangePeriod(
-                root="2023-01-01.2023-12-31"
-            ): ParameterChangeValue(root=np.inf),
-            ParameterChangePeriod(
-                root="2024-01-01.2024-12-31"
-            ): ParameterChangeValue(root=-np.inf),
+            "2023-01-01.2023-12-31": ParameterChangeValue(root=np.inf),
+            "2024-01-01.2024-12-31": ParameterChangeValue(root=-np.inf),
         }
 
         result = ParameterChangeDict(root=input_data)
@@ -78,8 +66,8 @@ class TestParameterChangeDict:
         }
 
         expected_output_data = {
-            ParameterChangePeriod(root="2023"): ParameterChangeValue(root=0.1),
-            ParameterChangePeriod(root="2024"): ParameterChangeValue(root=0.2),
+            "2023": ParameterChangeValue(root=0.1),
+            "2024": ParameterChangeValue(root=0.2),
         }
 
         result = ParameterChangeDict(root=input_data)
@@ -96,7 +84,7 @@ class TestParameterChangeDict:
         ):
             ParameterChangeDict(root=input_data)
 
-    def test_schema__given_invalid_key_type__raises_validation_error(self):
+    def test_schema__given_non_date_key_type__raises_validation_error(self):
         input_data = {123: 0.1, "2024-01-01.2024-12-31": 0.2}
 
         with pytest.raises(
@@ -104,32 +92,19 @@ class TestParameterChangeDict:
         ):
             ParameterChangeDict(root=input_data)
 
-
-class TestParameterChangePeriod:
-    def test_schema__given_valid_year__returns_valid_period(self):
-        input_data = "2023"
-
-        result = ParameterChangePeriod(root=input_data)
-
-        assert isinstance(result, ParameterChangePeriod)
-        assert result.root == input_data
-
-    def test_schema__given_valid_date_range__returns_valid_period(self):
-        input_data = "2023-01-01.2023-12-31"
-
-        result = ParameterChangePeriod(root=input_data)
-
-        assert isinstance(result, ParameterChangePeriod)
-        assert result.root == input_data
-
-    def test_schema__given_invalid_date_format__raises_validation_error(self):
-        input_data = "2023.01.01-2024.12.31"
+    def test_schema__given_incorrect_date_key_type__raises_validation_error(
+        self,
+    ):
+        input_data = {
+            "2023-01-01.2023-12-31": 0.1,
+            "2024-01-01.2024-12-31": 0.2,
+            "2024.01.01-2025.12.31": 0.3,
+        }
 
         with pytest.raises(
-            ValidationError,
-            match=r"validation errors? for ParameterChangePeriod",
+            ValidationError, match="validation error for ParameterChangeDict"
         ):
-            ParameterChangePeriod(root=input_data)
+            ParameterChangeDict(root=input_data)
 
 
 class TestParameterChangeValue:

--- a/tests/utils/test_reforms.py
+++ b/tests/utils/test_reforms.py
@@ -2,7 +2,12 @@ from pydantic import ValidationError
 import pytest
 import numpy as np
 
-from policyengine.utils.reforms import ParameterChangeDict, ParametricReform
+from policyengine.utils.reforms import (
+    ParameterChangeDict,
+    ParametricReform,
+    ParameterChangeValue,
+    ParameterChangePeriod,
+)
 
 
 class TestParameterChangeDict:
@@ -12,10 +17,19 @@ class TestParameterChangeDict:
             "2024-01-01.2024-12-31": 0.2,
         }
 
+        expected_output_data = {
+            ParameterChangePeriod(
+                root="2023-01-01.2023-12-31"
+            ): ParameterChangeValue(root=0.1),
+            ParameterChangePeriod(
+                root="2024-01-01.2024-12-31"
+            ): ParameterChangeValue(root=0.2),
+        }
+
         result = ParameterChangeDict(root=input_data)
 
         assert isinstance(result, ParameterChangeDict)
-        assert result.root == input_data
+        assert result.root == expected_output_data
 
     def test_schema__given_string_inputs__returns_valid_dict(self):
         input_data = {
@@ -23,10 +37,19 @@ class TestParameterChangeDict:
             "2024-01-01.2024-12-31": "0.2",
         }
 
+        expected_output_data = {
+            ParameterChangePeriod(
+                root="2023-01-01.2023-12-31"
+            ): ParameterChangeValue(root="0.1"),
+            ParameterChangePeriod(
+                root="2024-01-01.2024-12-31"
+            ): ParameterChangeValue(root="0.2"),
+        }
+
         result = ParameterChangeDict(root=input_data)
 
         assert isinstance(result, ParameterChangeDict)
-        assert result.root == input_data
+        assert result.root == expected_output_data
 
     def test_schema__given_infinity_string__returns_valid_dict(self):
         input_data = {
@@ -34,19 +57,42 @@ class TestParameterChangeDict:
             "2024-01-01.2024-12-31": "-Infinity",
         }
 
+        expected_output_data = {
+            ParameterChangePeriod(
+                root="2023-01-01.2023-12-31"
+            ): ParameterChangeValue(root=np.inf),
+            ParameterChangePeriod(
+                root="2024-01-01.2024-12-31"
+            ): ParameterChangeValue(root=-np.inf),
+        }
+
         result = ParameterChangeDict(root=input_data)
 
         assert isinstance(result, ParameterChangeDict)
-        assert result.root == {
-            "2023-01-01.2023-12-31": np.inf,
-            "2024-01-01.2024-12-31": -np.inf,
+        assert result.root == expected_output_data
+
+    def test_schema__given_yearly_input__returns_valid_dict(self):
+        input_data = {
+            "2023": 0.1,
+            "2024": 0.2,
         }
+
+        expected_output_data = {
+            ParameterChangePeriod(root="2023"): ParameterChangeValue(root=0.1),
+            ParameterChangePeriod(root="2024"): ParameterChangeValue(root=0.2),
+        }
+
+        result = ParameterChangeDict(root=input_data)
+
+        assert isinstance(result, ParameterChangeDict)
+        assert result.root == expected_output_data
 
     def test_schema__given_invalid_date_format__raises_validation_error(self):
         input_data = {"2023-01-01.2023-12-31": 0.1, "invalid_date_format": 0.2}
 
         with pytest.raises(
-            ValidationError, match="Invalid date format in key"
+            ValidationError,
+            match=r"validation errors? for ParameterChangeDict",
         ):
             ParameterChangeDict(root=input_data)
 
@@ -59,8 +105,93 @@ class TestParameterChangeDict:
             ParameterChangeDict(root=input_data)
 
 
+class TestParameterChangePeriod:
+    def test_schema__given_valid_year__returns_valid_period(self):
+        input_data = "2023"
+
+        result = ParameterChangePeriod(root=input_data)
+
+        assert isinstance(result, ParameterChangePeriod)
+        assert result.root == input_data
+
+    def test_schema__given_valid_date_range__returns_valid_period(self):
+        input_data = "2023-01-01.2023-12-31"
+
+        result = ParameterChangePeriod(root=input_data)
+
+        assert isinstance(result, ParameterChangePeriod)
+        assert result.root == input_data
+
+    def test_schema__given_invalid_date_format__raises_validation_error(self):
+        input_data = "2023.01.01-2024.12.31"
+
+        with pytest.raises(
+            ValidationError,
+            match=r"validation errors? for ParameterChangePeriod",
+        ):
+            ParameterChangePeriod(root=input_data)
+
+
+class TestParameterChangeValue:
+    def test_schema__given_float_input__returns_valid_value(self):
+        input_data = 0.1
+
+        result = ParameterChangeValue(root=input_data)
+
+        assert isinstance(result, ParameterChangeValue)
+        assert result.root == input_data
+
+    def test_schema__given_string_input__returns_valid_value(self):
+        input_data = "0.1"
+
+        result = ParameterChangeValue(root=input_data)
+
+        assert isinstance(result, ParameterChangeValue)
+        assert result.root == input_data
+
+    def test_schema__given_bool_input__returns_valid_value(self):
+        input_data = True
+
+        result = ParameterChangeValue(root=input_data)
+
+        assert isinstance(result, ParameterChangeValue)
+        assert result.root == input_data
+
+    def test_schema__given_infinity_string__returns_valid_value(self):
+        input_data = "Infinity"
+
+        result = ParameterChangeValue(root=input_data)
+
+        assert isinstance(result, ParameterChangeValue)
+        assert result.root == float("inf")
+
+    def test_schema__given_negative_infinity_string__returns_valid_value(self):
+        input_data = "-Infinity"
+
+        result = ParameterChangeValue(root=input_data)
+
+        assert isinstance(result, ParameterChangeValue)
+        assert result.root == float("-inf")
+
+    def test_schema__given_invalid_type__raises_validation_error(self):
+        input_data = [0.1, 0.2]
+
+        with pytest.raises(
+            ValidationError, match="validation error for ParameterChangeValue"
+        ):
+            ParameterChangeValue(root=input_data)
+
+    def test_schema__given_dict_input__raises_validation_error(self):
+        input_data = {"key": "value"}
+
+        with pytest.raises(
+            ValidationError, match="validation error for ParameterChangeValue"
+        ):
+            ParameterChangeValue(root=input_data)
+
+
 class TestParametricReform:
-    def test_schema__given_valid_dict__returns_valid_reform(self):
+    def test_schema__given_full_date_dict__returns_valid_reform(self):
         input_data = {
             "parameter1": {
                 "2023-01-01.2023-12-31": 0.1,
@@ -92,6 +223,62 @@ class TestParametricReform:
         assert isinstance(result, ParametricReform)
         assert result.root == expected_output_data
 
+    def test_schema__given_yearly_dict__returns_valid_reform(self):
+        input_data = {
+            "parameter1": {"2023": 0.1, "2024": 0.2},
+            "parameter2": {"2023": 0.3, "2024": 0.4},
+        }
+
+        expected_output_data = {
+            "parameter1": ParameterChangeDict(root={"2023": 0.1, "2024": 0.2}),
+            "parameter2": ParameterChangeDict(root={"2023": 0.3, "2024": 0.4}),
+        }
+
+        result = ParametricReform(root=input_data)
+
+        assert isinstance(result, ParametricReform)
+        assert result.root == expected_output_data
+
+    def test_schema__given_single_value_dict__returns_valid_reform(self):
+        input_data = {
+            "parameter1": 0.1,
+            "parameter2": 0.2,
+        }
+
+        expected_output_data = {
+            "parameter1": ParameterChangeValue(root=0.1),
+            "parameter2": ParameterChangeValue(root=0.2),
+        }
+
+        result = ParametricReform(root=input_data)
+
+        assert isinstance(result, ParametricReform)
+        assert result.root == expected_output_data
+
+    def test_schema__given_mixed_dict__returns_valid_reform(self):
+        input_data = {
+            "parameter1": {
+                "2023-01-01.2023-12-31": 0.1,
+                "2024-01-01.2024-12-31": 0.2,
+            },
+            "parameter2": 0.3,
+        }
+
+        expected_output_data = {
+            "parameter1": ParameterChangeDict(
+                root={
+                    "2023-01-01.2023-12-31": 0.1,
+                    "2024-01-01.2024-12-31": 0.2,
+                }
+            ),
+            "parameter2": ParameterChangeValue(root=0.3),
+        }
+
+        result = ParametricReform(root=input_data)
+
+        assert isinstance(result, ParametricReform)
+        assert result.root == expected_output_data
+
     def test_schema__given_invalid_key_type__raises_validation_error(self):
         input_data = {
             123: {"2023-01-01.2023-12-31": 0.1, "2024-01-01.2024-12-31": 0.2},
@@ -100,14 +287,6 @@ class TestParametricReform:
                 "2024-01-01.2024-12-31": 0.4,
             },
         }
-
-        with pytest.raises(
-            ValidationError, match=r"validation errors? for ParametricReform"
-        ):
-            ParametricReform(root=input_data)
-
-    def test_schema__given_dateless_structure__raises_validation_error(self):
-        input_data = {"parameter1": 0.1, "parameter2": 0.2}
 
         with pytest.raises(
             ValidationError, match=r"validation errors? for ParametricReform"

--- a/tests/utils/test_reforms.py
+++ b/tests/utils/test_reforms.py
@@ -6,7 +6,6 @@ from policyengine.utils.reforms import (
     ParameterChangeDict,
     ParametricReform,
     ParameterChangeValue,
-    ParameterChangePeriod,
 )
 
 


### PR DESCRIPTION
Fixes #115 

This PR:

1. Converts `"Infinity"` to `np.inf` and `"-Infinity"` to `-np.inf`
2. Adds testing
3. Creates subschemas for the `ParametricReform` schema to explicitly support and validate three reform input types:
```
{
  "param": 15_000
}
```
```
{
  "param": {
    "2024": 15_000
  }
}
```
```
{
  "param": {
    "2024-01-01.2025-12-31": 15_000
  }
}
```