### PR TITLE
Update microdf to v1.0.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update microdf_python dependency to >=1.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "policyengine-us>=1.213.1",
     "diskcache (>=5.6.3,<6.0.0)",
     "google-cloud-storage (>=3.1.0,<4.0.0)",
-    "microdf_python",
+    "microdf_python>=1.0.0",
     "getpass4",
     "pydantic"
 ]


### PR DESCRIPTION
This PR updates the microdf_python dependency to v1.0.0.

## Changes
- Add version constraint microdf_python>=1.0.0 (previously had no version constraint)

## Context
microdf v1.0.0 is a major breaking change that keeps only the core functionality used by PolicyEngine:
- MicroDataFrame
- MicroSeries  
- Gini calculation (via MicroSeries.gini())

This package uses MicroSeries extensively for economic analysis and comparison calculations.