### PR TITLE
Bump version to 3.1.16

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,7 @@
+- bump: patch
+  changes:
+    added:
+    - Poverty output type for single-simulation analysis
+    - Inequality output type with Gini coefficient
+    fixed:
+    - Labels now correctly apply to breakdown parameters


### PR DESCRIPTION
Adds poverty and inequality output types, and fixes label application to breakdown parameters.