### PR TITLE
Use Enhanced CPS as default dataset for US simulations

### DIFF
--- a/src/policyengine/tax_benefit_models/us/__init__.py
+++ b/src/policyengine/tax_benefit_models/us/__init__.py
@@ -12,6 +12,7 @@ if find_spec("policyengine_us") is not None:
         economic_impact_analysis,
     )
     from .datasets import (
+        DEFAULT_US_DATASET,
         PolicyEngineUSDataset,
         USYearData,
         create_datasets,
@@ -33,6 +34,7 @@ if find_spec("policyengine_us") is not None:
     PolicyEngineUSLatest.model_rebuild()
 
     __all__ = [
+        "DEFAULT_US_DATASET",
         "USYearData",
         "PolicyEngineUSDataset",
         "create_datasets",

--- a/src/policyengine/tax_benefit_models/us/datasets.py
+++ b/src/policyengine/tax_benefit_models/us/datasets.py
@@ -7,6 +7,9 @@ from pydantic import ConfigDict
 
 from policyengine.core import Dataset, YearData
 
+# Default dataset for US simulations
+DEFAULT_US_DATASET = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
+
 
 class USYearData(YearData):
     """Entity-level data for a single year."""
@@ -105,7 +108,7 @@ class PolicyEngineUSDataset(Dataset):
 
 def create_datasets(
     datasets: list[str] = [
-        "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5",
+        DEFAULT_US_DATASET,
     ],
     years: list[int] = [2024, 2025, 2026, 2027, 2028],
     data_folder: str = "./data",
@@ -297,7 +300,7 @@ def create_datasets(
 
 def load_datasets(
     datasets: list[str] = [
-        "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5",
+        DEFAULT_US_DATASET,
     ],
     years: list[int] = [2024, 2025, 2026, 2027, 2028],
     data_folder: str = "./data",
@@ -332,7 +335,7 @@ def load_datasets(
 
 def ensure_datasets(
     datasets: list[str] = [
-        "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5",
+        DEFAULT_US_DATASET,
     ],
     years: list[int] = [2024, 2025, 2026, 2027, 2028],
     data_folder: str = "./data",


### PR DESCRIPTION
Fixes #213

## Summary
- Add `DEFAULT_US_DATASET` constant to explicitly define the default dataset for US simulations
- The default is `enhanced_cps_2024.h5` from HuggingFace (`hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5`)
- Update `create_datasets()`, `load_datasets()`, and `ensure_datasets()` functions to use the constant
- Export the constant from the module for external use

## Test plan
- [ ] Verify `DEFAULT_US_DATASET` is accessible from `policyengine.tax_benefit_models.us`
- [ ] Verify dataset functions default to Enhanced CPS when no dataset is specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)