### PR TITLE
fix: Return newest blob when multiple match in metadata version lookup

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed `_get_blob_by_metadata_version` to return the newest blob (highest generation) when multiple blobs match the requested version.


### PR DESCRIPTION
Fixes #218

## Summary
- Fixed `_get_blob_by_metadata_version` to return the newest blob (highest generation number) when multiple blobs match the requested version
- Previously, the function returned the first matching blob, which was the oldest when re-uploaded blobs existed with the same version tag
- Added test to verify the newest blob is selected when multiple blobs share the same metadata version

## Test plan
- [x] All existing tests pass
- [x] Added new test `test_get_blob__metadata_version_returns_newest_when_multiple_match` to verify the fix
- [x] Updated existing tests to include generation numbers on mock blobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)