### PR TITLE
feat: Add default_value and value_type to Variable class

### DIFF
--- a/src/policyengine/core/variable.py
+++ b/src/policyengine/core/variable.py
@@ -13,3 +13,5 @@ class Variable(BaseModel):
     description: str | None = None
     data_type: type = None
     possible_values: list[Any] | None = None
+    default_value: Any = None
+    value_type: type | None = None

--- a/src/policyengine/tax_benefit_models/uk/model.py
+++ b/src/policyengine/tax_benefit_models/uk/model.py
@@ -126,6 +126,13 @@ class PolicyEngineUKLatest(TaxBenefitModelVersion):
         self.id = f"{self.model.id}@{self.version}"
 
         for var_obj in system.variables.values():
+            # Serialize default_value for JSON compatibility
+            default_val = var_obj.default_value
+            if var_obj.value_type is Enum:
+                default_val = default_val.name
+            elif var_obj.value_type is datetime.date:
+                default_val = default_val.isoformat()
+
             variable = Variable(
                 id=self.id + "-" + var_obj.name,
                 name=var_obj.name,
@@ -135,6 +142,8 @@ class PolicyEngineUKLatest(TaxBenefitModelVersion):
                 data_type=var_obj.value_type
                 if var_obj.value_type is not Enum
                 else str,
+                default_value=default_val,
+                value_type=var_obj.value_type,
             )
             if (
                 hasattr(var_obj, "possible_values")

--- a/src/policyengine/tax_benefit_models/us/model.py
+++ b/src/policyengine/tax_benefit_models/us/model.py
@@ -119,6 +119,13 @@ class PolicyEngineUSLatest(TaxBenefitModelVersion):
         self.id = f"{self.model.id}@{self.version}"
 
         for var_obj in system.variables.values():
+            # Serialize default_value for JSON compatibility
+            default_val = var_obj.default_value
+            if var_obj.value_type is Enum:
+                default_val = default_val.name
+            elif var_obj.value_type is datetime.date:
+                default_val = default_val.isoformat()
+
             variable = Variable(
                 id=self.id + "-" + var_obj.name,
                 name=var_obj.name,
@@ -128,6 +135,8 @@ class PolicyEngineUSLatest(TaxBenefitModelVersion):
                 data_type=var_obj.value_type
                 if var_obj.value_type is not Enum
                 else str,
+                default_value=default_val,
+                value_type=var_obj.value_type,
             )
             if (
                 hasattr(var_obj, "possible_values")


### PR DESCRIPTION
Fixes #226

## Summary
- Add `default_value` and `value_type` fields to the `Variable` class in policyengine.py
- Update US and UK model files to serialize `default_value` for JSON compatibility:
  - Enum values are converted to their `.name` string (e.g., "SINGLE")
  - `datetime.date` values are converted to ISO format string
  - Primitives (bool, int, float, str) are kept as-is
- `value_type` preserves the original type for downstream consumers

## Test plan
- [ ] Verify variables have `default_value` populated correctly
- [ ] Verify enum default values are serialized as strings
- [ ] Verify bool, int, float default values are preserved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)