### PR TITLE
Remove stale black dependency and config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ us = [
     "policyengine-us>=1.213.1",
 ]
 dev = [
-    "black",
     "pytest",
     "furo",
     "autodoc_pydantic",
@@ -69,24 +68,6 @@ testpaths = [
 filterwarnings = [
     "ignore::pydantic.warnings.PydanticDeprecatedSince20",
 ]
-
-[tool.black]
-line-length = 79
-target-version = ['py311']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
## Summary
- Removed `black` from dev dependencies
- Deleted the entire `[tool.black]` config section
- `ruff` is already configured for both linting and formatting

## Test plan
- [ ] CI passes (no black references in CI config)

Generated with [Claude Code](https://claude.com/claude-code)