### PR TITLE
perf: Skip redundant Lint and Test in Phase 2

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,7 +4,8 @@
 #   Versioning commits with message "Update package version".
 #   The commit pushes to main, re-triggering this workflow for Phase 2.
 #
-# Phase 2 (sentinel commit): Lint + Test → Publish to PyPI + GitHub Release
+# Phase 2 (sentinel commit): Publish to PyPI + GitHub Release
+#   Skips Lint + Test since the code is identical to Phase 1.
 
 name: Push to main
 
@@ -20,8 +21,9 @@ permissions:
   id-token: write
 
 jobs:
-  # ── Shared gates (always run) ─────────────────────────────
+  # ── Phase 1 gates (skip on sentinel commit) ─────────────────
   Lint:
+    if: github.event.head_commit.message != 'Update package version'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +35,7 @@ jobs:
         run: ruff check .
 
   Test:
+    if: github.event.head_commit.message != 'Update package version'
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -122,7 +125,6 @@ jobs:
   # ── Phase 2: Publish (only on sentinel commit) ────────────
   Publish:
     runs-on: ubuntu-latest
-    needs: [Lint, Test]
     if: github.event.head_commit.message == 'Update package version'
     env:
       GH_TOKEN: ${{ github.token }}

--- a/changelog.d/skip-phase2-lint-test.changed.md
+++ b/changelog.d/skip-phase2-lint-test.changed.md
@@ -1,0 +1,1 @@
+Skip redundant Lint and Test in Phase 2 of push workflow since code is identical to Phase 1


### PR DESCRIPTION
## Summary

- Skip Lint and Test jobs on the sentinel commit ("Update package version") since the code is identical to what Phase 1 already validated
- Publish job runs directly without waiting for redundant CI gates
- Saves ~10 min of macOS runner time per release

## Test plan

- [ ] Merge PR #261 first (GitHub App token fix)
- [ ] Merge this PR
- [ ] Verify Phase 2 runs Publish directly without Lint/Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)