### PR TITLE
Install h5py in Versioning job for TRACE TRO regen

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Preview changelog update
         run: ".github/get-changelog-diff.sh"
       - name: Install package for TRO regeneration
-        run: pip install -e .
+        run: pip install -e . h5py
       - name: Regenerate bundled TRACE TROs
         env:
           HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}


### PR DESCRIPTION
## Problem

The post-merge \`Versioning\` job (push.yaml) fails at the \"Regenerate bundled TRACE TROs\" step with \`ModuleNotFoundError: No module named 'h5py'\`. \`scripts/generate_trace_tros.py\` imports \`policyengine.core.release_manifest\`, which transitively loads \`policyengine.core.scoping_strategy\` → \`h5py\`. The job installs with \`pip install -e .\` (no extras), so h5py is not present.

Run that failed: https://github.com/PolicyEngine/policyengine.py/actions/runs/24608911376

## Fix

Install \`h5py\` alongside the bare package so the TRO regen script can import its dependency chain. Minimal change; no need to pull in the heavier \`[us]\`/\`[uk]\`/\`[dev]\` extras since the script does not touch the country model packages — it only reads bundled manifests, fetches HF data-release manifests over HTTPS, and emits JSON-LD.

## Test plan

- [x] Push to \`main\` runs the Versioning job; it should now publish the bumped package