### PR TITLE
Replace verbose dataset print in US budgetary impact example

### DIFF
--- a/examples/us_budgetary_impact.py
+++ b/examples/us_budgetary_impact.py
@@ -35,7 +35,7 @@ def main():
         data_folder="./data",
     )
     dataset = datasets[f"enhanced_cps_2024_{year}"]
-    print(f"  Loaded: {dataset}")
+    print(f"  Loaded: {dataset.name} ({len(dataset.data.person):,} people)")
 
     # ── Step 2: Define a reform ──
     # Example: double the standard deduction for single filers


### PR DESCRIPTION
Fixes #330

## Summary
- The line `print(f\"  Loaded: {dataset}\")` in `examples/us_budgetary_impact.py:38` relied on `PolicyEngineUSDataset`'s default `__repr__`, which dumps every entity DataFrame to stdout when the example runs.
- Replaced with a concise `dataset.name` + person count summary.

## Test plan
- [ ] `python examples/us_budgetary_impact.py` prints a single line for the load step instead of full DataFrame contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)