### PR TITLE
Document memory requirements for US budgetary impact example

### DIFF
--- a/examples/us_budgetary_impact.py
+++ b/examples/us_budgetary_impact.py
@@ -8,6 +8,14 @@ Demonstrates the canonical policyengine.py workflow:
 5. Use ChangeAggregate for targeted single-metric queries
 
 Run: python examples/us_budgetary_impact.py
+
+System requirements: this example holds two full enhanced-CPS US
+simulations in memory simultaneously to compute reform-vs-baseline
+deltas. On a 2026 dataset (~101k people / 41k households) peak memory
+has been observed at ~7.5 GiB RSS / ~80 GiB virtual, and end-to-end
+runtime is ~20 minutes on a developer laptop. Run with at least 16 GiB
+of free RAM and expect to close other memory-heavy applications. See
+https://github.com/PolicyEngine/policyengine.py/issues/328 for tracking.
 """
 
 import datetime


### PR DESCRIPTION
Refs #328

## Summary
- The US budgetary impact example holds two full enhanced-CPS simulations in memory simultaneously and has been observed to peak at ~7.5 GiB RSS / ~80 GiB virtual on a 2026 dataset, with ~20 minute end-to-end runtime.
- This PR adds an interim system-requirements note to the example header so users (and JOSS reviewers) know what to expect before running.
- The underlying memory footprint is upstream in `policyengine-us` and is tracked separately in #328 — this is documentation only.

## Test plan
- [ ] Read the updated docstring at the top of `examples/us_budgetary_impact.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)