### PR TITLE
Derive US program-statistics entity from variable metadata

### DIFF
--- a/changelog.d/derive-us-program-entities.changed.md
+++ b/changelog.d/derive-us-program-entities.changed.md
@@ -1,0 +1,1 @@
+Derive US program-statistics entity from variable metadata instead of duplicating it in the program list.

--- a/src/policyengine/tax_benefit_models/us/analysis.py
+++ b/src/policyengine/tax_benefit_models/us/analysis.py
@@ -28,18 +28,23 @@ from policyengine.outputs.poverty import (
 )
 from policyengine.utils.errors import format_conditional_error_detail
 
-US_PROGRAMS = {
-    "income_tax": {"entity": "tax_unit", "is_tax": True},
-    "employee_payroll_tax": {"entity": "tax_unit", "is_tax": True},
-    "state_income_tax": {"entity": "tax_unit", "is_tax": True},
-    "snap": {"entity": "spm_unit", "is_tax": False},
-    "tanf": {"entity": "spm_unit", "is_tax": False},
-    "ssi": {"entity": "person", "is_tax": False},
-    "social_security": {"entity": "person", "is_tax": False},
-    "medicare_cost": {"entity": "person", "is_tax": False},
-    "medicaid": {"entity": "person", "is_tax": False},
-    "eitc": {"entity": "tax_unit", "is_tax": False},
-    "ctc": {"entity": "tax_unit", "is_tax": False},
+# Map of US program-statistics variable name -> is_tax flag. The
+# entity for each program is derived from the variable's own metadata
+# at runtime (see ``_validate_program_statistics_config`` and
+# ``economic_impact_analysis``), so this list cannot silently drift
+# when policyengine-us moves a variable between entities.
+US_PROGRAMS: dict[str, bool] = {
+    "income_tax": True,
+    "employee_payroll_tax": True,
+    "state_income_tax": True,
+    "snap": False,
+    "tanf": False,
+    "ssi": False,
+    "social_security": False,
+    "medicare_cost": False,
+    "medicaid": False,
+    "eitc": False,
+    "ctc": False,
 }
 
 
@@ -95,7 +100,7 @@ def _validate_program_statistics_config(
     missing_outputs: set[tuple[str, str]] = set()
 
     simulations = (baseline_simulation, reform_simulation)
-    for program_name, program_info in US_PROGRAMS.items():
+    for program_name in US_PROGRAMS:
         for simulation in simulations:
             model_version = simulation.tax_benefit_model_version
             try:
@@ -153,14 +158,15 @@ def economic_impact_analysis(
         income_variable="household_net_income",
     )
 
+    model_version = baseline_simulation.tax_benefit_model_version
     program_statistics = []
-    for program_name, program_info in US_PROGRAMS.items():
+    for program_name, is_tax in US_PROGRAMS.items():
         stats = ProgramStatistics(
             baseline_simulation=baseline_simulation,
             reform_simulation=reform_simulation,
             program_name=program_name,
-            entity=program_info["entity"],
-            is_tax=program_info["is_tax"],
+            entity=model_version.get_variable(program_name).entity,
+            is_tax=is_tax,
         )
         stats.run()
         program_statistics.append(stats)

--- a/src/policyengine/tax_benefit_models/us/analysis.py
+++ b/src/policyengine/tax_benefit_models/us/analysis.py
@@ -28,23 +28,23 @@ from policyengine.outputs.poverty import (
 )
 from policyengine.utils.errors import format_conditional_error_detail
 
-# Map of US program-statistics variable name -> is_tax flag. The
+# Map of US program-statistics variable name -> program metadata. The
 # entity for each program is derived from the variable's own metadata
 # at runtime (see ``_validate_program_statistics_config`` and
 # ``economic_impact_analysis``), so this list cannot silently drift
 # when policyengine-us moves a variable between entities.
-US_PROGRAMS: dict[str, bool] = {
-    "income_tax": True,
-    "employee_payroll_tax": True,
-    "state_income_tax": True,
-    "snap": False,
-    "tanf": False,
-    "ssi": False,
-    "social_security": False,
-    "medicare_cost": False,
-    "medicaid": False,
-    "eitc": False,
-    "ctc": False,
+US_PROGRAMS: dict[str, dict] = {
+    "income_tax": {"is_tax": True},
+    "employee_payroll_tax": {"is_tax": True},
+    "state_income_tax": {"is_tax": True},
+    "snap": {"is_tax": False},
+    "tanf": {"is_tax": False},
+    "ssi": {"is_tax": False},
+    "social_security": {"is_tax": False},
+    "medicare_cost": {"is_tax": False},
+    "medicaid": {"is_tax": False},
+    "eitc": {"is_tax": False},
+    "ctc": {"is_tax": False},
 }
 
 
@@ -160,13 +160,13 @@ def economic_impact_analysis(
 
     model_version = baseline_simulation.tax_benefit_model_version
     program_statistics = []
-    for program_name, is_tax in US_PROGRAMS.items():
+    for program_name, program_info in US_PROGRAMS.items():
         stats = ProgramStatistics(
             baseline_simulation=baseline_simulation,
             reform_simulation=reform_simulation,
             program_name=program_name,
             entity=model_version.get_variable(program_name).entity,
-            is_tax=is_tax,
+            is_tax=program_info["is_tax"],
         )
         stats.run()
         program_statistics.append(stats)

--- a/tests/test_us_program_statistics.py
+++ b/tests/test_us_program_statistics.py
@@ -105,13 +105,13 @@ def test_us_program_statistics_config_runs_against_mocked_outputs(tmp_path):
 
     model_version = baseline.tax_benefit_model_version
     results = {}
-    for program_name, is_tax in US_PROGRAMS.items():
+    for program_name, program_info in US_PROGRAMS.items():
         stats = ProgramStatistics(
             baseline_simulation=baseline,
             reform_simulation=reform,
             program_name=program_name,
             entity=model_version.get_variable(program_name).entity,
-            is_tax=is_tax,
+            is_tax=program_info["is_tax"],
         )
         stats.run()
         results[program_name] = stats

--- a/tests/test_us_program_statistics.py
+++ b/tests/test_us_program_statistics.py
@@ -103,14 +103,15 @@ def test_us_program_statistics_config_runs_against_mocked_outputs(tmp_path):
 
     _validate_program_statistics_config(baseline, reform)
 
+    model_version = baseline.tax_benefit_model_version
     results = {}
-    for program_name, program_info in US_PROGRAMS.items():
+    for program_name, is_tax in US_PROGRAMS.items():
         stats = ProgramStatistics(
             baseline_simulation=baseline,
             reform_simulation=reform,
             program_name=program_name,
-            entity=program_info["entity"],
-            is_tax=program_info["is_tax"],
+            entity=model_version.get_variable(program_name).entity,
+            is_tax=is_tax,
         )
         stats.run()
         results[program_name] = stats
@@ -144,3 +145,11 @@ def test_us_program_statistics_config_fails_before_simulation_run(
         _validate_program_statistics_config(baseline, reform)
 
     assert "medicare_cost" in str(exc_info.value)
+
+
+def test_us_programs_entities_match_model_metadata():
+    for program_name in US_PROGRAMS:
+        assert program_name in us_latest.variables_by_name, (
+            f"{program_name} is not defined in the US model"
+        )
+

--- a/tests/test_us_program_statistics.py
+++ b/tests/test_us_program_statistics.py
@@ -152,4 +152,3 @@ def test_us_programs_entities_match_model_metadata():
         assert program_name in us_latest.variables_by_name, (
             f"{program_name} is not defined in the US model"
         )
-


### PR DESCRIPTION
Refs #326. Smaller follow-up on top of merged #327. Replaces #334.

## Summary
- Drop the duplicated `entity` field from `US_PROGRAMS`. Entity is now derived from `model_version.get_variable(name).entity` at runtime, so the program list cannot silently drift when `policyengine-us` moves a variable between entities.
- Keeps the "missing outputs" check that #327 added in `_validate_program_statistics_config` (variable must be both defined in the model **and** materialized in the simulation outputs).
- Adds `test_us_programs_entities_match_model_metadata` so a typo or rename in `US_PROGRAMS` is caught at test time, not at simulation time.

## Why this instead of #334
#334 was authored before #327 landed and (a) is severely behind `main`, (b) drops the materialized-outputs check from #327, and (c) introduced a `programs.py` module / `ProgramSpec` dataclasses that aren't load-bearing for the entity-derivation goal. This PR keeps only the durable improvement and stays minimal.

## Test plan
- [ ] `pytest tests/test_us_program_statistics.py` (covers entity derivation in `economic_impact_analysis` and the new metadata-match test).
- [ ] `pytest tests/test_aggregate.py tests/test_change_aggregate.py` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)