### PR TITLE
Fix reproducibility release follow-ups

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs/_build/html'
+          path: './docs/_site'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/changelog.d/repro-release-followups.fixed.md
+++ b/changelog.d/repro-release-followups.fixed.md
@@ -1,0 +1,1 @@
+Preserve core-package compatibility metadata when parsing data release manifests, and deploy the Quarto documentation output from the correct `_site` directory.

--- a/src/policyengine/provenance/manifest.py
+++ b/src/policyengine/provenance/manifest.py
@@ -34,9 +34,12 @@ class DataPackageVersion(PackageVersion):
     release_manifest_revision: Optional[str] = None
 
 
-class CompatibleModelPackage(BaseModel):
+class CompatiblePackage(BaseModel):
     name: str
     specifier: str
+
+
+CompatibleModelPackage = CompatiblePackage
 
 
 class BuiltWithModelPackage(PackageVersion):
@@ -47,6 +50,7 @@ class BuiltWithModelPackage(PackageVersion):
 class DataBuildInfo(BaseModel):
     build_id: Optional[str] = None
     built_at: Optional[str] = None
+    built_with_core_package: Optional[PackageVersion] = None
     built_with_model_package: Optional[BuiltWithModelPackage] = None
 
 
@@ -113,9 +117,8 @@ class DataReleaseArtifact(BaseModel):
 class DataReleaseManifest(BaseModel):
     schema_version: int
     data_package: PackageVersion
-    compatible_model_packages: list[CompatibleModelPackage] = Field(
-        default_factory=list
-    )
+    compatible_model_packages: list[CompatiblePackage] = Field(default_factory=list)
+    compatible_core_packages: list[CompatiblePackage] = Field(default_factory=list)
     default_datasets: dict[str, str] = Field(default_factory=dict)
     build: Optional[DataBuildInfo] = None
     artifacts: dict[str, DataReleaseArtifact] = Field(default_factory=dict)

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -180,6 +180,10 @@ class TestReleaseManifests:
             "build": {
                 "build_id": "policyengine-us-data-1.78.2",
                 "built_at": "2026-04-10T12:00:00Z",
+                "built_with_core_package": {
+                    "name": "policyengine-core",
+                    "version": "3.26.0",
+                },
                 "built_with_model_package": {
                     "name": "policyengine-us",
                     "version": "1.687.0",
@@ -189,6 +193,9 @@ class TestReleaseManifests:
             },
             "compatible_model_packages": [
                 {"name": "policyengine-us", "specifier": "==1.687.0"}
+            ],
+            "compatible_core_packages": [
+                {"name": "policyengine-core", "specifier": "==3.26.0"}
             ],
             "default_datasets": {"national": "enhanced_cps_2024"},
             "artifacts": {
@@ -215,8 +222,11 @@ class TestReleaseManifests:
         assert manifest.build is not None
         assert manifest.build.build_id == "policyengine-us-data-1.78.2"
         assert manifest.build.built_at == "2026-04-10T12:00:00Z"
+        assert manifest.build.built_with_core_package is not None
+        assert manifest.build.built_with_core_package.version == "3.26.0"
         assert manifest.build.built_with_model_package is not None
         assert manifest.build.built_with_model_package.version == "1.687.0"
+        assert manifest.compatible_core_packages[0].specifier == "==3.26.0"
         assert (
             manifest.artifacts["enhanced_cps_2024"].uri
             == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.78.2"


### PR DESCRIPTION
## Summary

- Preserve core-package compatibility and build metadata when parsing data release manifests.
- Upload Quarto docs from the actual `_site` output directory in the main push workflow.

## Checks

- `uv run ruff format --check src/policyengine/provenance/manifest.py tests/test_release_manifests.py`
- `uv run ruff check src/policyengine/provenance/manifest.py tests/test_release_manifests.py`
- `uv run --python 3.13 --extra dev python -m pytest tests/test_release_manifests.py -q`
- `make docs`
- Real US manifest smoke: `get_data_release_manifest("us")` preserves `compatible_core_packages[0].specifier == "==3.26.0"` and `build.built_with_core_package.version == "3.26.0"`.
