### PR TITLE
Point US manifest to core 3.26.1-compatible release

### DIFF
--- a/changelog.d/us-manifest-core-3261.fixed.md
+++ b/changelog.d/us-manifest-core-3261.fixed.md
@@ -1,0 +1,1 @@
+Point the bundled US data release manifest at a revision that certifies policyengine-core 3.26.1 compatibility.

--- a/src/policyengine/data/release_manifests/us.json
+++ b/src/policyengine/data/release_manifests/us.json
@@ -14,7 +14,7 @@
     "version": "1.78.2",
     "repo_id": "policyengine/policyengine-us-data",
     "release_manifest_path": "releases/1.78.2/release_manifest.json",
-    "release_manifest_revision": "2f1ea16b152cd9db4a4d2f1aad4d42e7484d5999"
+    "release_manifest_revision": "9cb665df0a546f9c3d79b496f8eb2dd55859d38d"
   },
   "certified_data_artifact": {
     "data_package": {

--- a/src/policyengine/data/release_manifests/us.trace.tro.jsonld
+++ b/src/policyengine/data/release_manifests/us.trace.tro.jsonld
@@ -17,7 +17,7 @@
         "schema:name": "PolicyEngine",
         "schema:url": "https://policyengine.org"
       },
-      "schema:dateCreated": "2026-05-09T05:55:53.876155Z",
+      "schema:dateCreated": "2026-05-09T09:38:11.356906Z",
       "schema:description": "TRACE TRO for certified runtime bundle us-4.4.1 covering the bundle manifest, the certified dataset artifact, the country model wheel, and the country data release manifest when it is available.",
       "schema:name": "policyengine us certified bundle TRO",
       "trov:createdWith": {
@@ -45,7 +45,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/data_release_manifest"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/2f1ea16b152cd9db4a4d2f1aad4d42e7484d5999/releases/1.78.2/release_manifest.json"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/9cb665df0a546f9c3d79b496f8eb2dd55859d38d/releases/1.78.2/release_manifest.json"
             },
             {
               "@id": "arrangement/1/location/dataset",
@@ -75,14 +75,14 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for us",
             "trov:mimeType": "application/json",
-            "trov:sha256": "ce126f23a20bf0f440471fad1e62f2cca7a3e5e4507c803d531de82e5eef284a"
+            "trov:sha256": "13a9b038eaab05712d6a38ad1ec003b8d1d689ec07de3ec0db41b757408111e6"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine-us-data release manifest 1.78.2",
             "trov:mimeType": "application/json",
-            "trov:sha256": "b58863a09028911abf2c8b1aef71bfd728df72f3e17f8b568b91f3b1cc22f60b"
+            "trov:sha256": "83aafd9fa3d33a444c0277aa4b31b2041a8785910bee30660773ab96e1b1c8b9"
           },
           {
             "@id": "composition/1/artifact/dataset",
@@ -102,7 +102,7 @@
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "13214d03923bf2773ea63ce189aec0a210ae2e4801194fe54aa900fbbf9b9069"
+          "trov:sha256": "bdf011a4e8dbf7446ea93676607ed8c6bfd82c47b7a50e29b1ad39b6ac050451"
         }
       },
       "trov:hasPerformance": {
@@ -111,17 +111,14 @@
         "pe:builtWithModelVersion": "1.647.0",
         "pe:certifiedBy": "policyengine.py bundled manifest",
         "pe:certifiedForModelVersion": "1.687.0",
-        "pe:ciGitRef": "refs/heads/main",
-        "pe:ciGitSha": "696103b2d964d1b86638d0e6650bb6a26dc0ed85",
-        "pe:ciRunUrl": "https://github.com/PolicyEngine/policyengine.py/actions/runs/25596581820",
         "pe:compatibilityBasis": "matching_data_build_fingerprint",
         "pe:dataBuildId": "policyengine-us-data-1.78.2",
-        "pe:emittedIn": "github-actions",
+        "pe:emittedIn": "local",
         "rdfs:comment": "Certification of build policyengine-us-data-1.78.2 for policyengine-us 1.687.0.",
         "trov:accessedArrangement": {
           "@id": "arrangement/1"
         },
-        "trov:startedAtTime": "2026-05-09T05:55:53.876155Z",
+        "trov:startedAtTime": "2026-05-09T09:38:11.356906Z",
         "trov:wasConductedBy": {
           "@id": "trs"
         }

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -72,7 +72,7 @@ class TestReleaseManifests:
         )
         assert (
             manifest.data_package.release_manifest_revision
-            == "2f1ea16b152cd9db4a4d2f1aad4d42e7484d5999"
+            == "9cb665df0a546f9c3d79b496f8eb2dd55859d38d"
         )
         assert manifest.certified_data_artifact is not None
         assert (
@@ -195,7 +195,8 @@ class TestReleaseManifests:
                 {"name": "policyengine-us", "specifier": "==1.687.0"}
             ],
             "compatible_core_packages": [
-                {"name": "policyengine-core", "specifier": "==3.26.0"}
+                {"name": "policyengine-core", "specifier": "==3.26.0"},
+                {"name": "policyengine-core", "specifier": "==3.26.1"},
             ],
             "default_datasets": {"national": "enhanced_cps_2024"},
             "artifacts": {
@@ -226,7 +227,10 @@ class TestReleaseManifests:
         assert manifest.build.built_with_core_package.version == "3.26.0"
         assert manifest.build.built_with_model_package is not None
         assert manifest.build.built_with_model_package.version == "1.687.0"
-        assert manifest.compatible_core_packages[0].specifier == "==3.26.0"
+        assert [package.specifier for package in manifest.compatible_core_packages] == [
+            "==3.26.0",
+            "==3.26.1",
+        ]
         assert (
             manifest.artifacts["enhanced_cps_2024"].uri
             == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@1.78.2"
@@ -234,7 +238,7 @@ class TestReleaseManifests:
         mock_get.assert_called_once()
         assert mock_get.call_args.args[0] == (
             "https://huggingface.co/policyengine/policyengine-us-data/resolve/"
-            "2f1ea16b152cd9db4a4d2f1aad4d42e7484d5999/"
+            "9cb665df0a546f9c3d79b496f8eb2dd55859d38d/"
             "releases/1.78.2/release_manifest.json"
         )
 
@@ -243,7 +247,7 @@ class TestReleaseManifests:
 
         assert https_release_manifest_uri(manifest.data_package) == (
             "https://huggingface.co/policyengine/policyengine-us-data/resolve/"
-            "2f1ea16b152cd9db4a4d2f1aad4d42e7484d5999/"
+            "9cb665df0a546f9c3d79b496f8eb2dd55859d38d/"
             "releases/1.78.2/release_manifest.json"
         )
 


### PR DESCRIPTION
## Summary
- points the bundled US data release manifest at the HF commit that certifies policyengine-core 3.26.1 compatibility
- regenerates the US TRACE TRO for the new immutable manifest URL
- updates manifest tests to preserve built-with core 3.26.0 while recognizing runtime compatibility with 3.26.1

## Tests
- python3 -m json.tool src/policyengine/data/release_manifests/us.json >/dev/null
- uv run python -m pytest tests/test_release_manifests.py tests/test_trace_tro.py tests/test_bundle_refresh.py
- uv run ruff format --check tests/test_release_manifests.py
- uv run ruff check tests/test_release_manifests.py