### PR TITLE
Update US release bundle to data 1.115.3

### DIFF
--- a/changelog.d/us-bundle-1.115.3.changed.md
+++ b/changelog.d/us-bundle-1.115.3.changed.md
@@ -1,0 +1,1 @@
+Updated the bundled US release manifest to policyengine-us 1.691.10 and policyengine-us-data 1.115.3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ uk = [
 ]
 us = [
     "policyengine_core>=3.26.1",
-    "policyengine-us==1.691.3",
+    "policyengine-us==1.691.10",
 ]
 dev = [
     "pytest",
@@ -62,7 +62,7 @@ dev = [
     "ruff>=0.9.0",
     "policyengine_core>=3.26.1",
     "policyengine-uk==2.88.14",
-    "policyengine-us==1.691.3",
+    "policyengine-us==1.691.10",
     "towncrier>=24.8.0",
     "mypy>=1.11.0",
     "pytest-cov>=5.0.0",

--- a/src/policyengine/data/release_manifests/us.json
+++ b/src/policyengine/data/release_manifests/us.json
@@ -5,34 +5,34 @@
   "policyengine_version": "4.5.0",
   "model_package": {
     "name": "policyengine-us",
-    "version": "1.691.3",
-    "sha256": "c5d37aa4442f23d48bd5d587a02876c89d83c6135809f12988cc39bd3a47e8b2",
-    "wheel_url": "https://files.pythonhosted.org/packages/2a/03/e21c872664f90dcc99f1fcf29d1da71409c50cf8a7798ff0596ad10d9400/policyengine_us-1.691.3-py3-none-any.whl"
+    "version": "1.691.10",
+    "sha256": "a2c8365f152c2ec3332e996c4003d560b433b6c204bdfcc73bf094a0ae49f10e",
+    "wheel_url": "https://files.pythonhosted.org/packages/a7/a3/53630e30285cb441cc96e5264621b1b9e5af3b648ccd176b376f0e03a458/policyengine_us-1.691.10-py3-none-any.whl"
   },
   "data_package": {
     "name": "policyengine-us-data",
-    "version": "1.113.1",
+    "version": "1.115.3",
     "repo_id": "policyengine/policyengine-us-data",
-    "release_manifest_path": "releases/1.113.1/release_manifest.json",
-    "release_manifest_revision": "99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+    "release_manifest_path": "releases/1.115.3/release_manifest.json",
+    "release_manifest_revision": "69fc39a7fece4c49ba87291e598e76b40568cc5d"
   },
   "certified_data_artifact": {
     "data_package": {
       "name": "policyengine-us-data",
-      "version": "1.113.1"
+      "version": "1.115.3"
     },
-    "build_id": "policyengine-us-data-1.113.1",
+    "build_id": "policyengine-us-data-1.115.3",
     "dataset": "enhanced_cps_2024",
-    "uri": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537",
-    "sha256": "0ce549af18753287c097718362b8cd5cdccfc47953acf7f282709d604cf314d2"
+    "uri": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@69fc39a7fece4c49ba87291e598e76b40568cc5d",
+    "sha256": "96965b0d9931d36beb29486b25fffee8b630e3b62c9376e7265976e02f7ab3ca"
   },
   "certification": {
     "compatibility_basis": "exact_build_model_version",
-    "data_build_id": "policyengine-us-data-1.113.1",
-    "built_with_model_version": "1.691.3",
-    "certified_for_model_version": "1.691.3",
+    "data_build_id": "policyengine-us-data-1.115.3",
+    "built_with_model_version": "1.691.10",
+    "certified_for_model_version": "1.691.10",
     "certified_by": "policyengine.py bundled manifest",
-    "data_build_fingerprint": "sha256:d891044ece8ec3338904771c879b98ec11a12f1090c074e5b8cee846825d8056"
+    "data_build_fingerprint": "sha256:b80625974285a9cff23bc2436fc46df98477997d50aea61e73b7f137b5121584"
   },
   "default_dataset": "enhanced_cps_2024",
   "datasets": {

--- a/src/policyengine/data/release_manifests/us.trace.tro.jsonld
+++ b/src/policyengine/data/release_manifests/us.trace.tro.jsonld
@@ -17,7 +17,7 @@
         "schema:name": "PolicyEngine",
         "schema:url": "https://policyengine.org"
       },
-      "schema:dateCreated": "2026-05-13T03:56:37.150215Z",
+      "schema:dateCreated": "2026-05-16T04:38:05.331368Z",
       "schema:description": "TRACE TRO for certified runtime bundle us-4.5.0 covering the bundle manifest, the certified dataset artifact, the country model wheel, and the country data release manifest when it is available.",
       "schema:name": "policyengine us certified bundle TRO",
       "trov:createdWith": {
@@ -45,7 +45,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/data_release_manifest"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/99e0ec7e784cdba43dd21ff1d80a081599a7a537/releases/1.113.1/release_manifest.json"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/69fc39a7fece4c49ba87291e598e76b40568cc5d/releases/1.115.3/release_manifest.json"
             },
             {
               "@id": "arrangement/1/location/dataset",
@@ -53,7 +53,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/dataset"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/99e0ec7e784cdba43dd21ff1d80a081599a7a537/enhanced_cps_2024.h5"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/69fc39a7fece4c49ba87291e598e76b40568cc5d/enhanced_cps_2024.h5"
             },
             {
               "@id": "arrangement/1/location/model_wheel",
@@ -61,7 +61,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/model_wheel"
               },
-              "trov:hasLocation": "https://files.pythonhosted.org/packages/2a/03/e21c872664f90dcc99f1fcf29d1da71409c50cf8a7798ff0596ad10d9400/policyengine_us-1.691.3-py3-none-any.whl"
+              "trov:hasLocation": "https://files.pythonhosted.org/packages/a7/a3/53630e30285cb441cc96e5264621b1b9e5af3b648ccd176b376f0e03a458/policyengine_us-1.691.10-py3-none-any.whl"
             }
           ]
         }
@@ -75,54 +75,51 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for us",
             "trov:mimeType": "application/json",
-            "trov:sha256": "b62f5676e4c17515e5aefde4101b58e1d8eb1dc7abe432e1ad8ccc5660bd50d0"
+            "trov:sha256": "2a0f005a25d2a6fae219c7f7a1f57652392298ea7d2a2764301c9025e7326804"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "policyengine-us-data release manifest 1.113.1",
+            "schema:name": "policyengine-us-data release manifest 1.115.3",
             "trov:mimeType": "application/json",
-            "trov:sha256": "d6b29ceff0cbf6a5cff4de94362ebc533dc5044c6a4155a46da7143140a8cb5f"
+            "trov:sha256": "50fec0baf199cf7f5bc5a16d9956d7c8d0fca3e2097b69dbb7f26cbbcf9114a9"
           },
           {
             "@id": "composition/1/artifact/dataset",
             "@type": "trov:ResearchArtifact",
             "schema:name": "enhanced_cps_2024",
             "trov:mimeType": "application/x-hdf5",
-            "trov:sha256": "0ce549af18753287c097718362b8cd5cdccfc47953acf7f282709d604cf314d2"
+            "trov:sha256": "96965b0d9931d36beb29486b25fffee8b630e3b62c9376e7265976e02f7ab3ca"
           },
           {
             "@id": "composition/1/artifact/model_wheel",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "policyengine-us==1.691.3 wheel",
+            "schema:name": "policyengine-us==1.691.10 wheel",
             "trov:mimeType": "application/zip",
-            "trov:sha256": "c5d37aa4442f23d48bd5d587a02876c89d83c6135809f12988cc39bd3a47e8b2"
+            "trov:sha256": "a2c8365f152c2ec3332e996c4003d560b433b6c204bdfcc73bf094a0ae49f10e"
           }
         ],
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "d6d03e72c1538a20ca214e5d80c5e11b6d270c1e57a0910e05ad682ec64b63d1"
+          "trov:sha256": "e5fa0f4b9b84c8e898deb4d5b47bc15f6203e50d68c551a60d57d8fcbc64901d"
         }
       },
       "trov:hasPerformance": {
         "@id": "trp/1",
         "@type": "trov:TransparentResearchPerformance",
-        "pe:builtWithModelVersion": "1.691.3",
+        "pe:builtWithModelVersion": "1.691.10",
         "pe:certifiedBy": "policyengine.py bundled manifest",
-        "pe:certifiedForModelVersion": "1.691.3",
-        "pe:ciGitRef": "refs/heads/main",
-        "pe:ciGitSha": "ab381161123fc076c13981f4131be9400f833810",
-        "pe:ciRunUrl": "https://github.com/PolicyEngine/policyengine.py/actions/runs/25952327329",
+        "pe:certifiedForModelVersion": "1.691.10",
         "pe:compatibilityBasis": "exact_build_model_version",
-        "pe:dataBuildFingerprint": "sha256:d891044ece8ec3338904771c879b98ec11a12f1090c074e5b8cee846825d8056",
-        "pe:dataBuildId": "policyengine-us-data-1.113.1",
-        "pe:emittedIn": "github-actions",
-        "rdfs:comment": "Certification of build policyengine-us-data-1.113.1 for policyengine-us 1.691.3.",
+        "pe:dataBuildFingerprint": "sha256:b80625974285a9cff23bc2436fc46df98477997d50aea61e73b7f137b5121584",
+        "pe:dataBuildId": "policyengine-us-data-1.115.3",
+        "pe:emittedIn": "local",
+        "rdfs:comment": "Certification of build policyengine-us-data-1.115.3 for policyengine-us 1.691.10.",
         "trov:accessedArrangement": {
           "@id": "arrangement/1"
         },
-        "trov:startedAtTime": "2026-05-13T03:56:37.150215Z",
+        "trov:startedAtTime": "2026-05-16T04:38:05.331368Z",
         "trov:wasConductedBy": {
           "@id": "trs"
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -113,12 +113,12 @@ class TestUSModel:
         assert us_latest.release_manifest is not None
         assert us_latest.release_manifest.country_id == "us"
         assert us_latest.model_package.name == "policyengine-us"
-        assert us_latest.model_package.version == "1.691.3"
+        assert us_latest.model_package.version == "1.691.10"
         assert us_latest.data_package.name == "policyengine-us-data"
-        assert us_latest.data_package.version == "1.113.1"
+        assert us_latest.data_package.version == "1.115.3"
         assert (
             us_latest.default_dataset_uri
-            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@69fc39a7fece4c49ba87291e598e76b40568cc5d"
         )
 
     def test_has_hundreds_of_parameters(self):

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -64,27 +64,27 @@ class TestReleaseManifests:
         assert manifest.country_id == "us"
         assert manifest.policyengine_version == POLICYENGINE_VERSION
         assert manifest.model_package.name == "policyengine-us"
-        assert manifest.model_package.version == "1.691.3"
+        assert manifest.model_package.version == "1.691.10"
         assert manifest.data_package.name == "policyengine-us-data"
-        assert manifest.data_package.version == "1.113.1"
+        assert manifest.data_package.version == "1.115.3"
         assert manifest.data_package.repo_id == "policyengine/policyengine-us-data"
         assert (
             manifest.data_package.release_manifest_path
-            == "releases/1.113.1/release_manifest.json"
+            == "releases/1.115.3/release_manifest.json"
         )
         assert (
             manifest.data_package.release_manifest_revision
-            == "99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            == "69fc39a7fece4c49ba87291e598e76b40568cc5d"
         )
         assert manifest.certified_data_artifact is not None
         assert (
-            manifest.certified_data_artifact.build_id == "policyengine-us-data-1.113.1"
+            manifest.certified_data_artifact.build_id == "policyengine-us-data-1.115.3"
         )
         assert manifest.certified_data_artifact.dataset == "enhanced_cps_2024"
         assert manifest.certification is not None
-        assert manifest.certification.data_build_id == "policyengine-us-data-1.113.1"
-        assert manifest.certification.built_with_model_version == "1.691.3"
-        assert manifest.certification.certified_for_model_version == "1.691.3"
+        assert manifest.certification.data_build_id == "policyengine-us-data-1.115.3"
+        assert manifest.certification.built_with_model_version == "1.691.10"
+        assert manifest.certification.certified_for_model_version == "1.691.10"
 
     def test__given_uk_manifest__then_has_pinned_model_and_data_packages(self):
         manifest = get_release_manifest("uk")
@@ -119,7 +119,7 @@ class TestReleaseManifests:
 
         assert (
             resolved
-            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@69fc39a7fece4c49ba87291e598e76b40568cc5d"
         )
 
     def test__given_uk_dataset_name__then_resolves_to_versioned_hf_url(self):
@@ -240,8 +240,8 @@ class TestReleaseManifests:
         mock_get.assert_called_once()
         assert mock_get.call_args.args[0] == (
             "https://huggingface.co/policyengine/policyengine-us-data/resolve/"
-            "99e0ec7e784cdba43dd21ff1d80a081599a7a537/"
-            "releases/1.113.1/release_manifest.json"
+            "69fc39a7fece4c49ba87291e598e76b40568cc5d/"
+            "releases/1.115.3/release_manifest.json"
         )
 
     def test__given_explicit_manifest_revision__then_builds_manifest_url(self):
@@ -249,8 +249,8 @@ class TestReleaseManifests:
 
         assert https_release_manifest_uri(manifest.data_package) == (
             "https://huggingface.co/policyengine/policyengine-us-data/resolve/"
-            "99e0ec7e784cdba43dd21ff1d80a081599a7a537/"
-            "releases/1.113.1/release_manifest.json"
+            "69fc39a7fece4c49ba87291e598e76b40568cc5d/"
+            "releases/1.115.3/release_manifest.json"
         )
 
     def test__given_release_manifest_artifact_uses_version_tag__then_rewrites_to_commit(
@@ -261,14 +261,14 @@ class TestReleaseManifests:
             "schema_version": 1,
             "data_package": {
                 "name": "policyengine-us-data",
-                "version": "1.113.1",
+                "version": "1.115.3",
             },
             "artifacts": {
                 "enhanced_cps_2024": {
                     "kind": "microdata",
                     "path": "enhanced_cps_2024.h5",
                     "repo_id": "policyengine/policyengine-us-data",
-                    "revision": "1.113.1",
+                    "revision": "1.115.3",
                     "sha256": "abc",
                     "size_bytes": 123,
                 }
@@ -283,7 +283,7 @@ class TestReleaseManifests:
 
         assert (
             manifest.artifacts["enhanced_cps_2024"].uri
-            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@69fc39a7fece4c49ba87291e598e76b40568cc5d"
         )
         assert (
             manifest.source_sha256
@@ -394,7 +394,7 @@ class TestReleaseManifests:
         ):
             certification = certify_data_release_compatibility(
                 "us",
-                runtime_model_version="1.691.3",
+                runtime_model_version="1.691.10",
             )
 
         assert certification == get_release_manifest("us").certification
@@ -410,7 +410,7 @@ class TestReleaseManifests:
         ):
             certification = certify_data_release_compatibility(
                 "us",
-                runtime_model_version="1.691.3",
+                runtime_model_version="1.691.10",
             )
 
         assert certification == get_release_manifest("us").certification

--- a/tests/test_trace_tro.py
+++ b/tests/test_trace_tro.py
@@ -24,6 +24,7 @@ from policyengine.provenance.manifest import (
     DataReleaseManifestUnavailableError,
     get_data_release_manifest,
     get_release_manifest,
+    https_dataset_uri,
 )
 from policyengine.provenance.trace import (
     POLICYENGINE_ORGANIZATION,
@@ -52,6 +53,17 @@ FAKE_WHEEL_URL = (
 
 def _fake_fetch_pypi(name: str, version: str) -> dict:
     return {"sha256": FAKE_WHEEL_SHA, "url": FAKE_WHEEL_URL}
+
+
+def _https_location_from_hf_uri(uri: str) -> str:
+    path_without_scheme = uri.removeprefix("hf://")
+    path_without_revision, revision = path_without_scheme.rsplit("@", 1)
+    repo_owner, repo_name, path_in_repo = path_without_revision.split("/", 2)
+    return https_dataset_uri(
+        repo_id=f"{repo_owner}/{repo_name}",
+        path_in_repo=path_in_repo,
+        revision=revision,
+    )
 
 
 def _us_data_release_manifest(
@@ -290,9 +302,9 @@ class TestBundleTRO:
         dataset_location = next(
             loc for loc in locations if loc["@id"].endswith("dataset")
         )
-        assert (
-            dataset_location["trov:hasLocation"]
-            == "https://huggingface.co/policyengine/policyengine-us-data/resolve/99e0ec7e784cdba43dd21ff1d80a081599a7a537/enhanced_cps_2024.h5"
+        assert country_manifest.certified_data_artifact is not None
+        assert dataset_location["trov:hasLocation"] == _https_location_from_hf_uri(
+            country_manifest.certified_data_artifact.uri
         )
         assert "/resolve/1.113.1/" not in dataset_location["trov:hasLocation"]
 

--- a/tests/test_us_regions.py
+++ b/tests/test_us_regions.py
@@ -4,6 +4,13 @@ from policyengine.countries.us.data import DISTRICT_COUNTS, US_STATES
 from policyengine.countries.us.regions import (
     us_region_registry,
 )
+from policyengine.provenance.manifest import get_release_manifest
+
+
+def _current_us_data_revision() -> str:
+    revision = get_release_manifest("us").data_package.release_manifest_revision
+    assert revision is not None
+    return revision
 
 
 class TestUSStates:
@@ -104,8 +111,8 @@ class TestUSRegionRegistry:
         assert national.label == "United States"
         assert national.region_type == "national"
         assert (
-            national.dataset_path
-            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            national.dataset_path == "hf://policyengine/policyengine-us-data/"
+            f"enhanced_cps_2024.h5@{_current_us_data_revision()}"
         )
 
     def test__given_us_registry__then_has_51_states(self):
@@ -133,8 +140,8 @@ class TestUSRegionRegistry:
         assert ca.region_type == "state"
         assert ca.parent_code == "us"
         assert (
-            ca.dataset_path
-            == "hf://policyengine/policyengine-us-data/states/CA.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            ca.dataset_path == "hf://policyengine/policyengine-us-data/"
+            f"states/CA.h5@{_current_us_data_revision()}"
         )
         assert ca.state_code == "CA"
         assert ca.state_name == "California"
@@ -166,8 +173,8 @@ class TestUSRegionRegistry:
         assert ca01.region_type == "congressional_district"
         assert ca01.parent_code == "state/ca"
         assert (
-            ca01.dataset_path
-            == "hf://policyengine/policyengine-us-data/districts/CA-01.h5@99e0ec7e784cdba43dd21ff1d80a081599a7a537"
+            ca01.dataset_path == "hf://policyengine/policyengine-us-data/"
+            f"districts/CA-01.h5@{_current_us_data_revision()}"
         )
         assert ca01.state_code == "CA"
         assert not ca01.requires_filter

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.4.4"
+version = "4.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "h5py", version = "3.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -2483,8 +2483,8 @@ requires-dist = [
     { name = "policyengine-core", marker = "extra == 'us'", specifier = ">=3.26.1" },
     { name = "policyengine-uk", marker = "extra == 'dev'", specifier = "==2.88.14" },
     { name = "policyengine-uk", marker = "extra == 'uk'", specifier = "==2.88.14" },
-    { name = "policyengine-us", marker = "extra == 'dev'", specifier = "==1.691.3" },
-    { name = "policyengine-us", marker = "extra == 'us'", specifier = "==1.691.3" },
+    { name = "policyengine-us", marker = "extra == 'dev'", specifier = "==1.691.10" },
+    { name = "policyengine-us", marker = "extra == 'us'", specifier = "==1.691.10" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -2547,7 +2547,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.3"
+version = "1.691.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2559,9 +2559,9 @@ dependencies = [
     { name = "tables", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/04/5e74890db670d7eb736f8fcb6070e6866950ba2e1d79e1d74f0dc5cfc58c/policyengine_us-1.691.3.tar.gz", hash = "sha256:3475c0e71ebe3396cfa2d138c62eeaa22a912c301d941418238109cf51a89e86", size = 9493068, upload-time = "2026-05-12T16:54:08.94Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/dc/f9b45c19c17ec7f34346feaf2aad363c859baba6cce8dfd42b779872f093/policyengine_us-1.691.10.tar.gz", hash = "sha256:f545db6f95ad49441262520613b905d5b3156fb05099712fa77908c49d86e804", size = 9507509, upload-time = "2026-05-16T03:36:23.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/03/e21c872664f90dcc99f1fcf29d1da71409c50cf8a7798ff0596ad10d9400/policyengine_us-1.691.3-py3-none-any.whl", hash = "sha256:c5d37aa4442f23d48bd5d587a02876c89d83c6135809f12988cc39bd3a47e8b2", size = 10008634, upload-time = "2026-05-12T16:54:05.956Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a3/53630e30285cb441cc96e5264621b1b9e5af3b648ccd176b376f0e03a458/policyengine_us-1.691.10-py3-none-any.whl", hash = "sha256:a2c8365f152c2ec3332e996c4003d560b433b6c204bdfcc73bf094a0ae49f10e", size = 10022315, upload-time = "2026-05-16T03:36:18.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update the bundled US manifest to policyengine-us 1.691.10 and policyengine-us-data 1.115.3
- refresh the US TRACE TRO and lockfile
- update bundle/model tests for the new certified manifest revision

## Validation
- `uv run pytest tests/test_release_manifests.py tests/test_models.py tests/test_us_long_term_datasets.py -q`
- `uv run ruff format --check . && uv run ruff check .`
- US smoke: policyengine-us 1.691.10, data 1.115.3, exact_build_model_version certification, 2026 household calculation succeeds
