### PR TITLE
Update UK release bundle to policyengine-uk 2.88.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ from policyengine.core import Simulation
 from policyengine.outputs.aggregate import Aggregate, AggregateType
 
 datasets = pe.uk.ensure_datasets(
-    datasets=["hf://policyengine/policyengine-uk-data/enhanced_frs_2023_24.h5"],
+    datasets=["enhanced_frs_2024_25"],
     years=[2026],
     data_folder="./data",
 )
-dataset = datasets["enhanced_frs_2023_24_2026"]
+dataset = datasets["enhanced_frs_2024_25_2026"]
 
 simulation = Simulation(dataset=dataset, tax_benefit_model_version=pe.uk.model)
 simulation.run()
@@ -170,7 +170,7 @@ Use the pinned interpreter and the UK extra to run the checked-in paper repro:
 uv run --python 3.14 --extra uk python examples/paper_repro_uk.py
 ```
 
-On first run this will create `./data/enhanced_frs_2023_24_year_2026.h5`.
+On first run this will create `./data/enhanced_frs_2024_25_year_2026.h5`.
 
 ## Features
 
@@ -192,7 +192,7 @@ from policyengine.tax_benefit_models.uk import PolicyEngineUKDataset
 
 dataset = PolicyEngineUKDataset(
     name="Representative data",
-    filepath="./data/frs_2023_24_year_2026.h5",
+    filepath="./data/frs_2024_25_year_2026.h5",
     year=2026,
 )
 dataset.load()

--- a/changelog.d/update-uk-bundle.changed.md
+++ b/changelog.d/update-uk-bundle.changed.md
@@ -1,0 +1,1 @@
+Update the UK release bundle to policyengine-uk 2.88.23 and policyengine-uk-data 1.55.12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ graph = [
 ]
 uk = [
     "policyengine_core>=3.26.1",
-    "policyengine-uk==2.88.20",
+    "policyengine-uk==2.88.23",
 ]
 us = [
     "policyengine_core==3.26.1",
@@ -63,7 +63,7 @@ dev = [
     "pytest-asyncio>=0.26.0",
     "ruff>=0.9.0",
     "policyengine_core==3.26.1",
-    "policyengine-uk==2.88.20",
+    "policyengine-uk==2.88.23",
     "policyengine-us==1.700.0",
     "towncrier>=24.8.0",
     "mypy>=1.11.0",

--- a/src/policyengine/data/release_manifests/uk.json
+++ b/src/policyengine/data/release_manifests/uk.json
@@ -5,49 +5,50 @@
   "policyengine_version": "4.12.1",
   "model_package": {
     "name": "policyengine-uk",
-    "version": "2.88.20",
-    "sha256": "8c3dacb868f3fb18296b8ef2475edaf543f57b8056d24a58bca59b108651f272",
-    "wheel_url": "https://files.pythonhosted.org/packages/32/f0/c0e7dbcc049501dc968da0a67de4976f305228328f96fe0ad08c65301c4f/policyengine_uk-2.88.20-py3-none-any.whl"
+    "version": "2.88.23",
+    "sha256": "5f8148a916a3221b5de7c8ce5971a0109412bbb693ee8f5f644b7f5a6368df1f",
+    "wheel_url": "https://files.pythonhosted.org/packages/23/d7/307c49731ad2ae73be8a4b0f410019d74ab6fd0b4cf270298392a1db54ef/policyengine_uk-2.88.23-py3-none-any.whl"
   },
   "data_package": {
     "name": "policyengine-uk-data",
-    "version": "1.55.10",
+    "version": "1.55.12",
     "repo_id": "policyengine/policyengine-uk-data-private",
     "release_manifest_path": "release_manifest.json",
-    "release_manifest_revision": "655dd07e4bb9c777b00dac044949611f1feb824f"
+    "release_manifest_revision": "4e25f9d6b67244340161098e76bb5e67148eb1e7"
   },
   "certified_data_artifact": {
     "data_package": {
       "name": "policyengine-uk-data",
-      "version": "1.55.10"
+      "version": "1.55.12"
     },
-    "build_id": "policyengine-uk-data-1.55.10",
-    "dataset": "enhanced_frs_2023_24",
-    "uri": "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f",
-    "sha256": "584ae33d80ca0431254610a3f8254d132da73477d31966d6446282861ecae50d"
+    "build_id": "policyengine-uk-data-1.55.12",
+    "dataset": "enhanced_frs_2024_25",
+    "uri": "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2024_25.h5@4e25f9d6b67244340161098e76bb5e67148eb1e7",
+    "sha256": "d0a6a178152cfb0168c61aaf25078b10d2447aebadee92af690e973ac2371141"
   },
   "certification": {
     "compatibility_basis": "exact_build_model_version",
-    "data_build_id": "policyengine-uk-data-1.55.10",
-    "built_with_model_version": "2.88.20",
-    "certified_for_model_version": "2.88.20",
-    "data_build_fingerprint": "sha256:77f149725a36055fd89961855230401852b0712d301c6e26d6d16565c6b23809",
-    "certified_by": "policyengine.py bundled manifest"
+    "data_build_id": "policyengine-uk-data-1.55.12",
+    "built_with_model_version": "2.88.23",
+    "certified_for_model_version": "2.88.23",
+    "data_build_fingerprint": "sha256:a9a1afc4f60c4614f2bbec47c318d812601e7bd1757e4121481421ec91815130",
+    "certified_by": "policyengine-uk-data release manifest",
+    "built_with_model_git_sha": "ca90dddf0d700f8d3fa45b5f2be6af857cb5141e"
   },
-  "default_dataset": "enhanced_frs_2023_24",
+  "default_dataset": "enhanced_frs_2024_25",
   "datasets": {
-    "frs_2023_24": {
-      "path": "frs_2023_24.h5",
-      "sha256": "df26d4d7af9d164aa2d064181b39290292d2f62bb26fee6126fc095fc06da292"
+    "frs_2024_25": {
+      "path": "frs_2024_25.h5",
+      "sha256": "715c5df79c15834dc4f62f05eee1f7813feb02df8128e8ca49ae4597ce5e94ad"
     },
-    "enhanced_frs_2023_24": {
-      "path": "enhanced_frs_2023_24.h5",
-      "sha256": "584ae33d80ca0431254610a3f8254d132da73477d31966d6446282861ecae50d"
+    "enhanced_frs_2024_25": {
+      "path": "enhanced_frs_2024_25.h5",
+      "sha256": "d0a6a178152cfb0168c61aaf25078b10d2447aebadee92af690e973ac2371141"
     }
   },
   "region_datasets": {
     "national": {
-      "path_template": "enhanced_frs_2023_24.h5"
+      "path_template": "enhanced_frs_2024_25.h5"
     }
   }
 }

--- a/src/policyengine/data/release_manifests/uk.trace.tro.jsonld
+++ b/src/policyengine/data/release_manifests/uk.trace.tro.jsonld
@@ -17,7 +17,7 @@
         "schema:name": "PolicyEngine",
         "schema:url": "https://policyengine.org"
       },
-      "schema:dateCreated": "2026-05-20T20:16:50.641086Z",
+      "schema:dateCreated": "2026-05-31T19:45:08.963190Z",
       "schema:description": "TRACE TRO for certified runtime bundle uk-4.12.1 covering the bundle manifest, the certified dataset artifact, the country model wheel, and the country data release manifest when it is available.",
       "schema:name": "policyengine uk certified bundle TRO",
       "trov:createdWith": {
@@ -45,7 +45,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/data_release_manifest"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-uk-data-private/resolve/655dd07e4bb9c777b00dac044949611f1feb824f/release_manifest.json"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-uk-data-private/resolve/4e25f9d6b67244340161098e76bb5e67148eb1e7/release_manifest.json"
             },
             {
               "@id": "arrangement/1/location/dataset",
@@ -53,7 +53,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/dataset"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-uk-data-private/resolve/655dd07e4bb9c777b00dac044949611f1feb824f/enhanced_frs_2023_24.h5"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-uk-data-private/resolve/4e25f9d6b67244340161098e76bb5e67148eb1e7/enhanced_frs_2024_25.h5"
             },
             {
               "@id": "arrangement/1/location/model_wheel",
@@ -61,7 +61,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/model_wheel"
               },
-              "trov:hasLocation": "https://files.pythonhosted.org/packages/32/f0/c0e7dbcc049501dc968da0a67de4976f305228328f96fe0ad08c65301c4f/policyengine_uk-2.88.20-py3-none-any.whl"
+              "trov:hasLocation": "https://files.pythonhosted.org/packages/23/d7/307c49731ad2ae73be8a4b0f410019d74ab6fd0b4cf270298392a1db54ef/policyengine_uk-2.88.23-py3-none-any.whl"
             }
           ]
         }
@@ -75,54 +75,52 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for uk",
             "trov:mimeType": "application/json",
-            "trov:sha256": "d73bcb0d37f3b0259f20cfb55777dee2a749a66671ca8c2f3f4816cea5bebd76"
+            "trov:sha256": "b03596858ae84d28b5254f6ccea641af72234762c5646dcb384dadab9e4403b4"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "policyengine-uk-data release manifest 1.55.10",
+            "schema:name": "policyengine-uk-data release manifest 1.55.12",
             "trov:mimeType": "application/json",
-            "trov:sha256": "9f41a0f14ca93d20e61d33419173c3fedc1c3ba295b6ca67dd3197a41643d179"
+            "trov:sha256": "ac2acc05a5fdcb44c91227b738e326e79c1e307c18841d32705432024de22011"
           },
           {
             "@id": "composition/1/artifact/dataset",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "enhanced_frs_2023_24",
+            "schema:name": "enhanced_frs_2024_25",
             "trov:mimeType": "application/x-hdf5",
-            "trov:sha256": "584ae33d80ca0431254610a3f8254d132da73477d31966d6446282861ecae50d"
+            "trov:sha256": "d0a6a178152cfb0168c61aaf25078b10d2447aebadee92af690e973ac2371141"
           },
           {
             "@id": "composition/1/artifact/model_wheel",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "policyengine-uk==2.88.20 wheel",
+            "schema:name": "policyengine-uk==2.88.23 wheel",
             "trov:mimeType": "application/zip",
-            "trov:sha256": "8c3dacb868f3fb18296b8ef2475edaf543f57b8056d24a58bca59b108651f272"
+            "trov:sha256": "5f8148a916a3221b5de7c8ce5971a0109412bbb693ee8f5f644b7f5a6368df1f"
           }
         ],
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "06c7b415b515d093711e2baad76e2a9055e483064094b7798b110c8b271ee8bb"
+          "trov:sha256": "c17b5134af288556c7aeaea9b86e2156fbb5a27fe4773bf70eee08598c204834"
         }
       },
       "trov:hasPerformance": {
         "@id": "trp/1",
         "@type": "trov:TransparentResearchPerformance",
-        "pe:builtWithModelVersion": "2.88.20",
-        "pe:certifiedBy": "policyengine.py bundled manifest",
-        "pe:certifiedForModelVersion": "2.88.20",
-        "pe:ciGitRef": "refs/heads/main",
-        "pe:ciGitSha": "7c3416d538f2eb90a0d6d9d9cd0e4eee9071f58a",
-        "pe:ciRunUrl": "https://github.com/PolicyEngine/policyengine.py/actions/runs/26668334869",
+        "pe:builtWithModelGitSha": "ca90dddf0d700f8d3fa45b5f2be6af857cb5141e",
+        "pe:builtWithModelVersion": "2.88.23",
+        "pe:certifiedBy": "policyengine-uk-data release manifest",
+        "pe:certifiedForModelVersion": "2.88.23",
         "pe:compatibilityBasis": "exact_build_model_version",
-        "pe:dataBuildFingerprint": "sha256:77f149725a36055fd89961855230401852b0712d301c6e26d6d16565c6b23809",
-        "pe:dataBuildId": "policyengine-uk-data-1.55.10",
-        "pe:emittedIn": "github-actions",
-        "rdfs:comment": "Certification of build policyengine-uk-data-1.55.10 for policyengine-uk 2.88.20.",
+        "pe:dataBuildFingerprint": "sha256:a9a1afc4f60c4614f2bbec47c318d812601e7bd1757e4121481421ec91815130",
+        "pe:dataBuildId": "policyengine-uk-data-1.55.12",
+        "pe:emittedIn": "local",
+        "rdfs:comment": "Certification of build policyengine-uk-data-1.55.12 for policyengine-uk 2.88.23.",
         "trov:accessedArrangement": {
           "@id": "arrangement/1"
         },
-        "trov:startedAtTime": "2026-05-20T20:16:50.641086Z",
+        "trov:startedAtTime": "2026-05-31T19:45:08.963190Z",
         "trov:wasConductedBy": {
           "@id": "trs"
         }

--- a/src/policyengine/tax_benefit_models/uk/datasets.py
+++ b/src/policyengine/tax_benefit_models/uk/datasets.py
@@ -102,8 +102,8 @@ class PolicyEngineUKDataset(Dataset):
 
 def create_datasets(
     datasets: list[str] = [
-        "frs_2023_24",
-        "enhanced_frs_2023_24",
+        "frs_2024_25",
+        "enhanced_frs_2024_25",
     ],
     years: list[int] = [2026, 2027, 2028, 2029, 2030],
     data_folder: str = "./data",
@@ -184,8 +184,8 @@ def create_datasets(
 
 def load_datasets(
     datasets: list[str] = [
-        "frs_2023_24",
-        "enhanced_frs_2023_24",
+        "frs_2024_25",
+        "enhanced_frs_2024_25",
     ],
     years: list[int] = [2026, 2027, 2028, 2029, 2030],
     data_folder: str = "./data",
@@ -212,8 +212,8 @@ def load_datasets(
 
 def ensure_datasets(
     datasets: list[str] = [
-        "frs_2023_24",
-        "enhanced_frs_2023_24",
+        "frs_2024_25",
+        "enhanced_frs_2024_25",
     ],
     years: list[int] = [2026, 2027, 2028, 2029, 2030],
     data_folder: str = "./data",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,14 @@ import re
 from policyengine.tax_benefit_models.uk import uk_latest
 from policyengine.tax_benefit_models.us import us_latest
 
+UK_MODEL_VERSION = "2.88.23"
+UK_DATA_RELEASE_VERSION = "1.55.12"
+UK_DATA_RELEASE_REVISION = "4e25f9d6b67244340161098e76bb5e67148eb1e7"
+UK_DEFAULT_DATASET_URI = (
+    "hf://policyengine/policyengine-uk-data-private/"
+    f"enhanced_frs_2024_25.h5@{UK_DATA_RELEASE_REVISION}"
+)
+
 
 class TestUKModel:
     """Tests for PolicyEngine UK model."""
@@ -29,13 +37,10 @@ class TestUKModel:
         assert uk_latest.release_manifest is not None
         assert uk_latest.release_manifest.country_id == "uk"
         assert uk_latest.model_package.name == "policyengine-uk"
-        assert uk_latest.model_package.version == "2.88.20"
+        assert uk_latest.model_package.version == UK_MODEL_VERSION
         assert uk_latest.data_package.name == "policyengine-uk-data"
-        assert uk_latest.data_package.version == "1.55.10"
-        assert (
-            uk_latest.default_dataset_uri
-            == "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
-        )
+        assert uk_latest.data_package.version == UK_DATA_RELEASE_VERSION
+        assert uk_latest.default_dataset_uri == UK_DEFAULT_DATASET_URI
 
     def test_has_hundreds_of_parameters(self):
         """UK model should have hundreds of parameters."""

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -54,6 +54,17 @@ US_ENHANCED_CPS_MANAGED_URI = (
     "hf://policyengine/policyengine-us-data/"
     f"enhanced_cps_2024.h5@{US_DATA_RELEASE_REVISION}"
 )
+UK_MODEL_VERSION = "2.88.23"
+UK_DATA_RELEASE_VERSION = "1.55.12"
+UK_DATA_RELEASE_REVISION = "4e25f9d6b67244340161098e76bb5e67148eb1e7"
+UK_DEFAULT_DATASET = "enhanced_frs_2024_25"
+UK_DEFAULT_DATASET_URI = (
+    "hf://policyengine/policyengine-uk-data-private/"
+    f"{UK_DEFAULT_DATASET}.h5@{UK_DATA_RELEASE_REVISION}"
+)
+UK_DATA_BUILD_FINGERPRINT = (
+    "sha256:a9a1afc4f60c4614f2bbec47c318d812601e7bd1757e4121481421ec91815130"
+)
 
 
 def _response_with_json(payload: dict) -> MagicMock:
@@ -120,24 +131,28 @@ class TestReleaseManifests:
         assert manifest.country_id == "uk"
         assert manifest.policyengine_version == POLICYENGINE_VERSION
         assert manifest.model_package.name == "policyengine-uk"
-        assert manifest.model_package.version == "2.88.20"
+        assert manifest.model_package.version == UK_MODEL_VERSION
         assert manifest.data_package.name == "policyengine-uk-data"
-        assert manifest.data_package.version == "1.55.10"
+        assert manifest.data_package.version == UK_DATA_RELEASE_VERSION
         assert (
             manifest.data_package.repo_id == "policyengine/policyengine-uk-data-private"
         )
         assert manifest.certified_data_artifact is not None
         assert (
-            manifest.certified_data_artifact.build_id == "policyengine-uk-data-1.55.10"
+            manifest.certified_data_artifact.build_id
+            == f"policyengine-uk-data-{UK_DATA_RELEASE_VERSION}"
         )
-        assert manifest.certified_data_artifact.dataset == "enhanced_frs_2023_24"
+        assert manifest.certified_data_artifact.dataset == UK_DEFAULT_DATASET
         assert manifest.certification is not None
-        assert manifest.certification.data_build_id == "policyengine-uk-data-1.55.10"
-        assert manifest.certification.built_with_model_version == "2.88.20"
-        assert manifest.certification.certified_for_model_version == "2.88.20"
+        assert (
+            manifest.certification.data_build_id
+            == f"policyengine-uk-data-{UK_DATA_RELEASE_VERSION}"
+        )
+        assert manifest.certification.built_with_model_version == UK_MODEL_VERSION
+        assert manifest.certification.certified_for_model_version == UK_MODEL_VERSION
         assert (
             manifest.certification.data_build_fingerprint
-            == "sha256:77f149725a36055fd89961855230401852b0712d301c6e26d6d16565c6b23809"
+            == UK_DATA_BUILD_FINGERPRINT
         )
 
     def test__given_us_dataset_name__then_resolves_to_versioned_hf_url(self):
@@ -164,12 +179,9 @@ class TestReleaseManifests:
         )
 
     def test__given_uk_dataset_name__then_resolves_to_versioned_hf_url(self):
-        resolved = resolve_dataset_reference("uk", "enhanced_frs_2023_24")
+        resolved = resolve_dataset_reference("uk", UK_DEFAULT_DATASET)
 
-        assert (
-            resolved
-            == "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
-        )
+        assert resolved == UK_DEFAULT_DATASET_URI
 
     def test__given_explicit_url__then_resolution_is_noop(self):
         url = "hf://policyengine/policyengine-us-data/cps_2023.h5@1.73.0"
@@ -621,12 +633,15 @@ class TestReleaseManifests:
         bundle = model_version.release_bundle
 
         assert bundle["bundle_id"] == f"uk-{POLICYENGINE_VERSION}"
-        assert bundle["default_dataset"] == "enhanced_frs_2023_24"
+        assert bundle["default_dataset"] == UK_DEFAULT_DATASET
         assert bundle["default_dataset_uri"] == manifest.default_dataset_uri
-        assert bundle["certified_data_build_id"] == "policyengine-uk-data-1.55.10"
-        assert bundle["data_build_model_version"] == "2.88.20"
+        assert (
+            bundle["certified_data_build_id"]
+            == f"policyengine-uk-data-{UK_DATA_RELEASE_VERSION}"
+        )
+        assert bundle["data_build_model_version"] == UK_MODEL_VERSION
         assert bundle["compatibility_basis"] == "exact_build_model_version"
-        assert bundle["certified_by"] == "policyengine.py bundled manifest"
+        assert bundle["certified_by"] == "policyengine-uk-data release manifest"
 
     def test__given_runtime_certification__then_release_bundle_prefers_runtime_value(
         self,
@@ -737,22 +752,22 @@ class TestReleaseManifests:
             ),
             patch(
                 "policyengine.tax_benefit_models.uk.model.materialize_dataset_source",
-                return_value="/tmp/enhanced_frs_2023_24.h5",
+                return_value=f"/tmp/{UK_DEFAULT_DATASET}.h5",
             ),
         ):
-            microsim = managed_uk_microsimulation(dataset="enhanced_frs_2023_24")
+            microsim = managed_uk_microsimulation(dataset=UK_DEFAULT_DATASET)
 
         dataset = mock_microsimulation.call_args.kwargs["dataset"]
-        assert dataset == "/tmp/enhanced_frs_2023_24.h5"
+        assert dataset == f"/tmp/{UK_DEFAULT_DATASET}.h5"
         assert (
             microsim.policyengine_bundle["policyengine_version"] == POLICYENGINE_VERSION
         )
-        assert microsim.policyengine_bundle["runtime_dataset"] == "enhanced_frs_2023_24"
+        assert microsim.policyengine_bundle["runtime_dataset"] == UK_DEFAULT_DATASET
         assert microsim.policyengine_bundle["runtime_dataset_uri"] == (
-            "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
+            UK_DEFAULT_DATASET_URI
         )
         dataset_source = microsim.policyengine_bundle["runtime_dataset_source"]
-        assert dataset_source == "/tmp/enhanced_frs_2023_24.h5"
+        assert dataset_source == f"/tmp/{UK_DEFAULT_DATASET}.h5"
 
     def test__given_uk_unmanaged_dataset_uri__then_source_is_not_rewritten(self):
         dataset = "hf://policyengine/policyengine-uk-data-private/frs_2022_23.h5@1.40.4"

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -151,8 +151,7 @@ class TestReleaseManifests:
         assert manifest.certification.built_with_model_version == UK_MODEL_VERSION
         assert manifest.certification.certified_for_model_version == UK_MODEL_VERSION
         assert (
-            manifest.certification.data_build_fingerprint
-            == UK_DATA_BUILD_FINGERPRINT
+            manifest.certification.data_build_fingerprint == UK_DATA_BUILD_FINGERPRINT
         )
 
     def test__given_us_dataset_name__then_resolves_to_versioned_hf_url(self):

--- a/tests/test_uk_regions.py
+++ b/tests/test_uk_regions.py
@@ -16,6 +16,12 @@ from policyengine.data.uk_geography_assets import (
     LOCAL_AUTHORITY_ASSET_SPEC,
 )
 
+UK_DATA_RELEASE_REVISION = "4e25f9d6b67244340161098e76bb5e67148eb1e7"
+UK_DEFAULT_DATASET_URI = (
+    "hf://policyengine/policyengine-uk-data-private/"
+    f"enhanced_frs_2024_25.h5@{UK_DATA_RELEASE_REVISION}"
+)
+
 
 class TestUKCountries:
     """Tests for UK country definitions."""
@@ -75,10 +81,7 @@ class TestUKRegionRegistry:
         assert national.code == "uk"
         assert national.label == "United Kingdom"
         assert national.region_type == "national"
-        assert (
-            national.dataset_path
-            == "hf://policyengine/policyengine-uk-data-private/enhanced_frs_2023_24.h5@655dd07e4bb9c777b00dac044949611f1feb824f"
-        )
+        assert national.dataset_path == UK_DEFAULT_DATASET_URI
         assert not national.requires_filter
 
     def test__given_uk_registry__then_has_four_country_regions(self):

--- a/uv.lock
+++ b/uv.lock
@@ -2820,7 +2820,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.12.0"
+version = "4.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -2895,8 +2895,8 @@ requires-dist = [
     { name = "policyengine-core", marker = "extra == 'dev'", specifier = "==3.26.1" },
     { name = "policyengine-core", marker = "extra == 'uk'", specifier = ">=3.26.1" },
     { name = "policyengine-core", marker = "extra == 'us'", specifier = "==3.26.1" },
-    { name = "policyengine-uk", marker = "extra == 'dev'", specifier = "==2.88.20" },
-    { name = "policyengine-uk", marker = "extra == 'uk'", specifier = "==2.88.20" },
+    { name = "policyengine-uk", marker = "extra == 'dev'", specifier = "==2.88.23" },
+    { name = "policyengine-uk", marker = "extra == 'uk'", specifier = "==2.88.23" },
     { name = "policyengine-us", marker = "extra == 'dev'", specifier = "==1.700.0" },
     { name = "policyengine-us", marker = "extra == 'us'", specifier = "==1.700.0" },
     { name = "psutil", specifier = ">=5.9.0" },
@@ -2944,7 +2944,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-uk"
-version = "2.88.20"
+version = "2.88.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2954,9 +2954,9 @@ dependencies = [
     { name = "tables", version = "3.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "tables", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/11/64c8b0269e68d42ffdc58c74b1975dcb6a67487de526855182ecc2479fb1/policyengine_uk-2.88.20.tar.gz", hash = "sha256:3c3939f4b4dc78be2747ec459bad2b5f341580be031af4004a554ce0c3f59682", size = 1189714, upload-time = "2026-05-20T17:38:13.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/11/5f7bc2510a5bbfea1409ce0ed3545ad56a364f4e286aa51a58c7362b7f6f/policyengine_uk-2.88.23.tar.gz", hash = "sha256:2cb245c116723b11a7bdb126fb1c79d5cd6624417d5ba643a65589335deccd9b", size = 1195492, upload-time = "2026-05-23T14:15:05.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/f0/c0e7dbcc049501dc968da0a67de4976f305228328f96fe0ad08c65301c4f/policyengine_uk-2.88.20-py3-none-any.whl", hash = "sha256:8c3dacb868f3fb18296b8ef2475edaf543f57b8056d24a58bca59b108651f272", size = 1918240, upload-time = "2026-05-20T17:38:11.347Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d7/307c49731ad2ae73be8a4b0f410019d74ab6fd0b4cf270298392a1db54ef/policyengine_uk-2.88.23-py3-none-any.whl", hash = "sha256:5f8148a916a3221b5de7c8ce5971a0109412bbb693ee8f5f644b7f5a6368df1f", size = 1930806, upload-time = "2026-05-23T14:15:03.441Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- update the UK bundle to policyengine-uk 2.88.23 and policyengine-uk-data 1.55.12
- switch default UK managed datasets and docs from FRS 2023-24 to FRS 2024-25
- regenerate the UK release manifest and TRACE TRO against HF release commit 4e25f9d6b67244340161098e76bb5e67148eb1e7

## Validation
- built and uploaded the policyengine-uk-data 1.55.12 HF release artifacts
- HUGGING_FACE_TOKEN=... uv run --extra dev python -m pytest tests/test_release_manifests.py tests/test_models.py tests/test_uk_regions.py -q

## Notes
- HF release is finalized at policyengine/policyengine-uk-data-private tag 1.55.12, commit 4e25f9d6b67244340161098e76bb5e67148eb1e7
- the upload script completed HF upload, then failed on the GCS mirror with 403 because max@policyengine.org lacks storage.objects.create on policyengine-uk-data-private