### PR TITLE
Update US release manifest to MP eCPS artifact

### DIFF
--- a/changelog.d/mp-ecps-2024-data.changed.md
+++ b/changelog.d/mp-ecps-2024-data.changed.md
@@ -1,0 +1,1 @@
+Update the bundled US release manifest to the MP/eCPS 2024 `enhanced_cps_2024` artifact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ uk = [
 ]
 us = [
     "policyengine_core==3.26.1",
-    "policyengine-us==1.715.2",
+    "policyengine-us==1.715.3",
 ]
 dev = [
     "pytest",
@@ -64,7 +64,7 @@ dev = [
     "ruff>=0.9.0",
     "policyengine_core==3.26.1",
     "policyengine-uk==2.88.20",
-    "policyengine-us==1.715.2",
+    "policyengine-us==1.715.3",
     "towncrier>=24.8.0",
     "mypy>=1.11.0",
     "pytest-cov>=5.0.0",

--- a/src/policyengine/data/release_manifests/us.json
+++ b/src/policyengine/data/release_manifests/us.json
@@ -5,40 +5,40 @@
   "policyengine_version": "4.14.0",
   "model_package": {
     "name": "policyengine-us",
-    "version": "1.715.2",
-    "sha256": "abf079828419762f5c4b0291a70f6e424744200f237e1ae0f06e25f10130c399",
-    "wheel_url": "https://files.pythonhosted.org/packages/45/a1/1d56bdbb69d7ce06bedd3892203a75ac3350a90c0b5fcea2fb50db46670f/policyengine_us-1.715.2-py3-none-any.whl"
+    "version": "1.715.3",
+    "sha256": "a34f305871f702d94f7a4d220bfd5312f11d83a417e793566892541871dfded3",
+    "wheel_url": "https://files.pythonhosted.org/packages/f4/0f/e6b594d46fffeb6e40db3a51441cec6a6e76ade2b178eab3836528dbc15c/policyengine_us-1.715.3-py3-none-any.whl"
   },
   "data_package": {
     "name": "policyengine-us-data",
-    "version": "1.115.5",
+    "version": "mp-ecps-2024-2cdd45d-20260605",
     "repo_id": "policyengine/policyengine-us-data",
-    "release_manifest_path": "release_manifest.json",
-    "release_manifest_revision": "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+    "release_manifest_path": "releases/mp-ecps-2024-2cdd45d-20260605/release_manifest.json",
+    "release_manifest_revision": "a091769a2d5e075762c520950ca8ca7f87017225"
   },
   "certified_data_artifact": {
     "data_package": {
       "name": "policyengine-us-data",
-      "version": "1.115.5"
+      "version": "mp-ecps-2024-2cdd45d-20260605"
     },
-    "build_id": "policyengine-us-data-1.115.5",
+    "build_id": "microplex-us-2cdd45d-nodeferred-gzip1-20260605",
     "dataset": "enhanced_cps_2024",
-    "uri": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@d47fb5475144260a75467d2f2e22b2d5d53d4d57",
-    "sha256": "0a6b961ad363a421bde99f2c8e5d8f20370bcba45fd303050537a25bdd805b14"
+    "uri": "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@a091769a2d5e075762c520950ca8ca7f87017225",
+    "sha256": "8d2ccab299d59a3dea075781346f85ed45f74562dfe599977131e026acde93a8"
   },
   "certification": {
-    "compatibility_basis": "legacy_compatible_model_package",
-    "data_build_id": "policyengine-us-data-1.115.5",
-    "built_with_model_version": "1.700.0",
-    "certified_for_model_version": "1.715.2",
+    "compatibility_basis": "exact_build_model_version",
+    "data_build_id": "microplex-us-2cdd45d-nodeferred-gzip1-20260605",
+    "built_with_model_version": "1.715.3",
+    "certified_for_model_version": "1.715.3",
     "certified_by": "policyengine-us-data release manifest",
-    "data_build_fingerprint": "sha256:b0862de383ffcbe45f4ba0aa9c6aaec286cd4c6688c6ccb33f939bc176f9a8a0"
+    "built_with_model_git_sha": "f7458313c86fa580fb1e43a2f18252d67cf76e4a"
   },
   "default_dataset": "enhanced_cps_2024",
   "datasets": {
     "enhanced_cps_2024": {
       "path": "enhanced_cps_2024.h5",
-      "sha256": "0a6b961ad363a421bde99f2c8e5d8f20370bcba45fd303050537a25bdd805b14"
+      "sha256": "8d2ccab299d59a3dea075781346f85ed45f74562dfe599977131e026acde93a8"
     },
     "long_term_cps_2026": {
       "path": "long_term/2026.h5",

--- a/src/policyengine/data/release_manifests/us.trace.tro.jsonld
+++ b/src/policyengine/data/release_manifests/us.trace.tro.jsonld
@@ -17,7 +17,7 @@
         "schema:name": "PolicyEngine",
         "schema:url": "https://policyengine.org"
       },
-      "schema:dateCreated": "2026-05-20T19:37:01.417728Z",
+      "schema:dateCreated": "2026-06-05T15:35:21Z",
       "schema:description": "TRACE TRO for certified runtime bundle us-4.14.0 covering the bundle manifest, the certified dataset artifact, the country model wheel, and the country data release manifest when it is available.",
       "schema:name": "policyengine us certified bundle TRO",
       "trov:createdWith": {
@@ -45,7 +45,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/data_release_manifest"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/d47fb5475144260a75467d2f2e22b2d5d53d4d57/release_manifest.json"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/a091769a2d5e075762c520950ca8ca7f87017225/releases/mp-ecps-2024-2cdd45d-20260605/release_manifest.json"
             },
             {
               "@id": "arrangement/1/location/dataset",
@@ -53,7 +53,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/dataset"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/d47fb5475144260a75467d2f2e22b2d5d53d4d57/enhanced_cps_2024.h5"
+              "trov:hasLocation": "https://huggingface.co/policyengine/policyengine-us-data/resolve/a091769a2d5e075762c520950ca8ca7f87017225/enhanced_cps_2024.h5"
             },
             {
               "@id": "arrangement/1/location/model_wheel",
@@ -61,7 +61,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/model_wheel"
               },
-              "trov:hasLocation": "https://files.pythonhosted.org/packages/45/a1/1d56bdbb69d7ce06bedd3892203a75ac3350a90c0b5fcea2fb50db46670f/policyengine_us-1.715.2-py3-none-any.whl"
+              "trov:hasLocation": "https://files.pythonhosted.org/packages/f4/0f/e6b594d46fffeb6e40db3a51441cec6a6e76ade2b178eab3836528dbc15c/policyengine_us-1.715.3-py3-none-any.whl"
             }
           ]
         }
@@ -75,54 +75,51 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for us",
             "trov:mimeType": "application/json",
-            "trov:sha256": "5220fd5a0ca14d747c6f99e5b131d26b878aea710b4ce117b619c447e3182118"
+            "trov:sha256": "50cedf670b20f38127b1df58ff2c1b32e352afa8de88aa3c2e663267a03572ba"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "policyengine-us-data release manifest 1.115.5",
+            "schema:name": "policyengine-us-data release manifest mp-ecps-2024-2cdd45d-20260605",
             "trov:mimeType": "application/json",
-            "trov:sha256": "577fbf704da44f63d0432dc3e80f3686eb3a32020d13ca6b7b6cf7eb60b4742c"
+            "trov:sha256": "4961f6ee85124b0459d9318d09e0160611eab8cca3c08fedbc8481898e4abdfe"
           },
           {
             "@id": "composition/1/artifact/dataset",
             "@type": "trov:ResearchArtifact",
             "schema:name": "enhanced_cps_2024",
             "trov:mimeType": "application/x-hdf5",
-            "trov:sha256": "0a6b961ad363a421bde99f2c8e5d8f20370bcba45fd303050537a25bdd805b14"
+            "trov:sha256": "8d2ccab299d59a3dea075781346f85ed45f74562dfe599977131e026acde93a8"
           },
           {
             "@id": "composition/1/artifact/model_wheel",
             "@type": "trov:ResearchArtifact",
-            "schema:name": "policyengine-us==1.715.2 wheel",
+            "schema:name": "policyengine-us==1.715.3 wheel",
             "trov:mimeType": "application/zip",
-            "trov:sha256": "abf079828419762f5c4b0291a70f6e424744200f237e1ae0f06e25f10130c399"
+            "trov:sha256": "a34f305871f702d94f7a4d220bfd5312f11d83a417e793566892541871dfded3"
           }
         ],
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "fef6409ca1ccefaf60674e1a9ba123566df1238ddbad8537ef741c5098b03ad4"
+          "trov:sha256": "3dcaf22d396327cf9694d67e4b1660a9ba98ed864f18a58e2d48717e10ade843"
         }
       },
       "trov:hasPerformance": {
         "@id": "trp/1",
         "@type": "trov:TransparentResearchPerformance",
-        "pe:builtWithModelVersion": "1.700.0",
+        "pe:builtWithModelGitSha": "f7458313c86fa580fb1e43a2f18252d67cf76e4a",
+        "pe:builtWithModelVersion": "1.715.3",
         "pe:certifiedBy": "policyengine-us-data release manifest",
-        "pe:certifiedForModelVersion": "1.715.2",
-        "pe:ciGitRef": "refs/heads/main",
-        "pe:ciGitSha": "420ca00d1d2ec861ac8a22bf50f7a8aad78788c4",
-        "pe:ciRunUrl": "https://github.com/PolicyEngine/policyengine.py/actions/runs/26966664566",
-        "pe:compatibilityBasis": "legacy_compatible_model_package",
-        "pe:dataBuildFingerprint": "sha256:b0862de383ffcbe45f4ba0aa9c6aaec286cd4c6688c6ccb33f939bc176f9a8a0",
-        "pe:dataBuildId": "policyengine-us-data-1.115.5",
-        "pe:emittedIn": "github-actions",
-        "rdfs:comment": "Certification of build policyengine-us-data-1.115.5 for policyengine-us 1.715.2.",
+        "pe:certifiedForModelVersion": "1.715.3",
+        "pe:compatibilityBasis": "exact_build_model_version",
+        "pe:dataBuildId": "microplex-us-2cdd45d-nodeferred-gzip1-20260605",
+        "pe:emittedIn": "local",
+        "rdfs:comment": "Certification of build microplex-us-2cdd45d-nodeferred-gzip1-20260605 for policyengine-us 1.715.3.",
         "trov:accessedArrangement": {
           "@id": "arrangement/1"
         },
-        "trov:startedAtTime": "2026-05-20T19:37:01.417728Z",
+        "trov:startedAtTime": "2026-06-05T15:35:21Z",
         "trov:wasConductedBy": {
           "@id": "trs"
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -113,12 +113,12 @@ class TestUSModel:
         assert us_latest.release_manifest is not None
         assert us_latest.release_manifest.country_id == "us"
         assert us_latest.model_package.name == "policyengine-us"
-        assert us_latest.model_package.version == "1.715.2"
+        assert us_latest.model_package.version == "1.715.3"
         assert us_latest.data_package.name == "policyengine-us-data"
-        assert us_latest.data_package.version == "1.115.5"
+        assert us_latest.data_package.version == "mp-ecps-2024-2cdd45d-20260605"
         assert (
             us_latest.default_dataset_uri
-            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+            == "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5@a091769a2d5e075762c520950ca8ca7f87017225"
         )
 
     def test_has_hundreds_of_parameters(self):

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -41,11 +41,13 @@ POLICYENGINE_VERSION = re.search(
     PYPROJECT.read_text(),
     re.MULTILINE,
 ).group(1)
-US_MODEL_VERSION = "1.715.2"
-US_BUILT_WITH_MODEL_VERSION = "1.700.0"
-US_DATA_RELEASE_VERSION = "1.115.5"
-US_DATA_RELEASE_PATH = "release_manifest.json"
-US_DATA_RELEASE_REVISION = "d47fb5475144260a75467d2f2e22b2d5d53d4d57"
+US_MODEL_VERSION = "1.715.3"
+US_BUILT_WITH_MODEL_VERSION = "1.715.3"
+US_BUILT_WITH_MODEL_GIT_SHA = "f7458313c86fa580fb1e43a2f18252d67cf76e4a"
+US_DATA_RELEASE_VERSION = "mp-ecps-2024-2cdd45d-20260605"
+US_DATA_BUILD_ID = "microplex-us-2cdd45d-nodeferred-gzip1-20260605"
+US_DATA_RELEASE_PATH = "releases/mp-ecps-2024-2cdd45d-20260605/release_manifest.json"
+US_DATA_RELEASE_REVISION = "a091769a2d5e075762c520950ca8ca7f87017225"
 US_CERTIFICATION_SOURCE = "policyengine-us-data release manifest"
 US_DEFAULT_DATASET_URI = (
     "hf://policyengine/policyengine-us-data/"
@@ -100,23 +102,18 @@ class TestReleaseManifests:
             manifest.data_package.release_manifest_revision == US_DATA_RELEASE_REVISION
         )
         assert manifest.certified_data_artifact is not None
-        assert (
-            manifest.certified_data_artifact.build_id
-            == f"policyengine-us-data-{US_DATA_RELEASE_VERSION}"
-        )
+        assert manifest.certified_data_artifact.build_id == US_DATA_BUILD_ID
         assert manifest.certified_data_artifact.dataset == "enhanced_cps_2024"
         assert manifest.certification is not None
-        assert (
-            manifest.certification.data_build_id
-            == f"policyengine-us-data-{US_DATA_RELEASE_VERSION}"
-        )
-        assert (
-            manifest.certification.compatibility_basis
-            == "legacy_compatible_model_package"
-        )
+        assert manifest.certification.data_build_id == US_DATA_BUILD_ID
+        assert manifest.certification.compatibility_basis == "exact_build_model_version"
         assert (
             manifest.certification.built_with_model_version
             == US_BUILT_WITH_MODEL_VERSION
+        )
+        assert (
+            manifest.certification.built_with_model_git_sha
+            == US_BUILT_WITH_MODEL_GIT_SHA
         )
         assert manifest.certification.certified_for_model_version == US_MODEL_VERSION
 

--- a/uv.lock
+++ b/uv.lock
@@ -2820,7 +2820,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.13.0"
+version = "4.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -2897,8 +2897,8 @@ requires-dist = [
     { name = "policyengine-core", marker = "extra == 'us'", specifier = "==3.26.1" },
     { name = "policyengine-uk", marker = "extra == 'dev'", specifier = "==2.88.20" },
     { name = "policyengine-uk", marker = "extra == 'uk'", specifier = "==2.88.20" },
-    { name = "policyengine-us", marker = "extra == 'dev'", specifier = "==1.715.2" },
-    { name = "policyengine-us", marker = "extra == 'us'", specifier = "==1.715.2" },
+    { name = "policyengine-us", marker = "extra == 'dev'", specifier = "==1.715.3" },
+    { name = "policyengine-us", marker = "extra == 'us'", specifier = "==1.715.3" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -2961,7 +2961,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.715.2"
+version = "1.715.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2973,9 +2973,9 @@ dependencies = [
     { name = "tables", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/ef/d87bb056084897932e083b0412976a386d29062834b0e697afa044642a75/policyengine_us-1.715.2.tar.gz", hash = "sha256:b3990ae9b7c694d2cbf497e6256850aca7be5a5a73ac98330682aba9edd61b61", size = 10014025, upload-time = "2026-05-29T02:48:39.527Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/bc/ea8cf84d7653d4d76d1f7b05feb74722ff903637c616357610de1fd3b431/policyengine_us-1.715.3.tar.gz", hash = "sha256:5b41b22be90ef155a9440bcae7dd26115c887cad92ae8a51d9080a9692053b66", size = 10014788, upload-time = "2026-05-29T21:33:02.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/a1/1d56bdbb69d7ce06bedd3892203a75ac3350a90c0b5fcea2fb50db46670f/policyengine_us-1.715.2-py3-none-any.whl", hash = "sha256:abf079828419762f5c4b0291a70f6e424744200f237e1ae0f06e25f10130c399", size = 11035379, upload-time = "2026-05-29T02:48:35.193Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0f/e6b594d46fffeb6e40db3a51441cec6a6e76ade2b178eab3836528dbc15c/policyengine_us-1.715.3-py3-none-any.whl", hash = "sha256:a34f305871f702d94f7a4d220bfd5312f11d83a417e793566892541871dfded3", size = 11037631, upload-time = "2026-05-29T21:32:59.464Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- refresh the bundled US release manifest to the MP/eCPS 2024 enhanced_cps_2024 artifact on Hugging Face revision mp-ecps-2024-2cdd45d-20260605 / commit a091769a
- bump the US optional/dev model pin to policyengine-us==1.715.3, matching the data release build package
- regenerate the US TRACE TRO and update manifest metadata tests for the exact-build certification

## Verification
- uv run --python 3.13 --extra dev ruff check pyproject.toml src/policyengine/data/release_manifests tests/test_release_manifests.py tests/test_trace_tro.py tests/test_models.py tests/test_dataset_sources.py tests/test_import_policyengine_bundle.py
- uv run --python 3.13 --extra dev pytest tests/test_release_manifests.py tests/test_trace_tro.py tests/test_models.py tests/test_dataset_sources.py tests/test_import_policyengine_bundle.py -q
- uv run --python 3.13 --extra dev python - <<'PY'
from policyengine.tax_benefit_models.us import managed_microsimulation, us_latest
sim = managed_microsimulation()
series = sim.calc('employment_income_before_lsr', period=2024)
print(us_latest.default_dataset_uri)
print(sim.policyengine_bundle['runtime_dataset_uri'])
print(len(series))
print(float(series.sum()))
PY