### PR TITLE
Support dataset-type HF repos in dataset materialization

### DIFF
--- a/changelog.d/populace-dataset-repo-support.added.md
+++ b/changelog.d/populace-dataset-repo-support.added.md
@@ -1,0 +1,1 @@
+Support dataset-type Hugging Face repos in dataset materialization (retry with repo_type=dataset before surfacing the original failure).

--- a/src/policyengine/provenance/dataset_sources.py
+++ b/src/policyengine/provenance/dataset_sources.py
@@ -96,10 +96,24 @@ def materialize_dataset_source(
         )
 
         reference = parse_hf_uri(dataset_source)
-        return download_huggingface_dataset(
-            reference.repo_id,
-            reference.path,
-            version=_select_version(reference.version, version),
-        )
+        try:
+            return download_huggingface_dataset(
+                reference.repo_id,
+                reference.path,
+                version=_select_version(reference.version, version),
+            )
+        except Exception:
+            # The core helper assumes a model-type repo; certified data
+            # releases may live in dataset-type repos (e.g.
+            # policyengine/populace-us). Retry with the dataset repo type
+            # before surfacing the original failure.
+            from huggingface_hub import hf_hub_download
+
+            return hf_hub_download(
+                repo_id=reference.repo_id,
+                repo_type="dataset",
+                filename=reference.path,
+                revision=_select_version(reference.version, version),
+            )
 
     return dataset_source


### PR DESCRIPTION
policyengine_core's download helper assumes model-type HF repos; certified data releases can live in dataset-type repos (the populace-us release, certified-track via policyengine-bundles#25, is one). Adds a dataset-repo retry in `materialize_dataset_source` before surfacing the original failure. Verified end-to-end against `hf://policyengine/populace-us/populace_us_2024.h5` — resolution, download, and dataset-key creation all work through `ensure_datasets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)