### PR TITLE
Require Populace US source coverage certification

### DIFF
--- a/changelog.d/populace-us-source-coverage-certification.changed.md
+++ b/changelog.d/populace-us-source-coverage-certification.changed.md
@@ -1,0 +1,1 @@
+Require Populace-US data certification to verify the supplemental source-coverage release file before vendoring a release manifest.

--- a/docs/engineering/skills/data-certification.md
+++ b/docs/engineering/skills/data-certification.md
@@ -53,7 +53,8 @@ A certification PR should normally change only:
 
 Hard failures (certification refuses): missing national default dataset,
 default dataset absent from artifacts, any artifact without a revision pin,
-unreachable certified dataset, unknown country.
+unreachable certified dataset, missing required supplemental release files
+(for example Populace-US `us_source_coverage.json`), unknown country.
 
 Certification gate: the model version must either exactly match the
 build-time model (`compatibility_basis: built_with_model_package`) or be

--- a/src/policyengine/provenance/certification.py
+++ b/src/policyengine/provenance/certification.py
@@ -62,6 +62,7 @@ COUNTRY_MODEL_PACKAGES = {
 CERTIFIED_BY = "policyengine.py certification"
 BASIS_BUILT_WITH = "built_with_model_package"
 BASIS_PUBLISHER_CLAIM = "compatible_model_packages"
+POPULACE_US_SOURCE_COVERAGE_FILE = "us_source_coverage.json"
 
 
 class CertificationError(ValueError):
@@ -111,6 +112,15 @@ def https_manifest_url(parts: dict) -> str:
     return (
         f"https://huggingface.co/{prefix}{parts['repo_id']}/resolve/"
         f"{parts['revision']}/{parts['path']}"
+    )
+
+
+def https_release_file_url(parts: dict, filename: str) -> str:
+    prefix = "datasets/" if parts["repo_type"] == "dataset" else ""
+    release_dir = parts["path"].rsplit("/", 1)[0]
+    return (
+        f"https://huggingface.co/{prefix}{parts['repo_id']}/resolve/"
+        f"{parts['revision']}/{release_dir}/{filename}"
     )
 
 
@@ -219,6 +229,37 @@ def head_artifact(artifact, token: Optional[str] = None) -> bool:
         if response.status_code == 200:
             return True
     return False
+
+
+def head_release_file(
+    uri_parts: dict, filename: str, token: Optional[str] = None
+) -> bool:
+    url = https_release_file_url(uri_parts, filename)
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        response = requests.head(
+            url,
+            headers=headers,
+            timeout=HF_REQUEST_TIMEOUT_SECONDS,
+            allow_redirects=True,
+        )
+    except requests.RequestException:
+        return False
+    return response.status_code == 200
+
+
+def required_supplemental_release_files(
+    country: str,
+    manifest: DataReleaseManifest,
+    uri_parts: dict,
+) -> tuple[str, ...]:
+    if (
+        country == "us"
+        and manifest.data_package.name == "populace-data"
+        and uri_parts["repo_id"] == "policyengine/populace-us"
+    ):
+        return (POPULACE_US_SOURCE_COVERAGE_FILE,)
+    return ()
 
 
 def build_country_manifest_payload(
@@ -346,6 +387,13 @@ def certify_data_release(
     compatibility_basis, warnings = validate_release_manifest(
         manifest, model_package, model_version
     )
+
+    for filename in required_supplemental_release_files(country, manifest, uri_parts):
+        if not head_release_file(uri_parts, filename, token=token):
+            raise CertificationError(
+                "Required supplemental release file is not reachable: "
+                f"{filename} at {https_release_file_url(uri_parts, filename)}"
+            )
 
     default_artifact = manifest.artifacts[manifest.default_datasets["national"]]
     if check_artifacts and not head_artifact(default_artifact, token=token):

--- a/tests/test_certify_data_release.py
+++ b/tests/test_certify_data_release.py
@@ -208,6 +208,10 @@ class TestCertifyDataRelease:
                 return_value=True,
             ),
             patch(
+                "policyengine.provenance.certification.head_release_file",
+                return_value=True,
+            ),
+            patch(
                 "policyengine.provenance.certification.fetch_pypi_wheel_metadata",
                 return_value={"sha256": "d" * 64, "url": "https://example"},
             ),
@@ -225,6 +229,29 @@ class TestCertifyDataRelease:
         assert result.dataset_count == 2
         assert result.build_id == TAG
 
+    def test__given_missing_populace_us_source_coverage__then_raises(self, tmp_path):
+        response = MagicMock()
+        response.status_code = 200
+        response.content = json.dumps(_release_manifest_payload()).encode()
+
+        with (
+            patch(
+                "policyengine.provenance.certification.requests.get",
+                return_value=response,
+            ),
+            patch(
+                "policyengine.provenance.certification.head_release_file",
+                return_value=False,
+            ),
+            pytest.raises(CertificationError, match="us_source_coverage.json"),
+        ):
+            certify_data_release(
+                country="us",
+                manifest_uri=MANIFEST_URI,
+                model_version="1.723.0",
+                output_dir=tmp_path,
+            )
+
     def test__given_unreachable_artifact__then_raises(self, tmp_path):
         response = MagicMock()
         response.status_code = 200
@@ -238,6 +265,10 @@ class TestCertifyDataRelease:
             patch(
                 "policyengine.provenance.certification.head_artifact",
                 return_value=False,
+            ),
+            patch(
+                "policyengine.provenance.certification.head_release_file",
+                return_value=True,
             ),
             pytest.raises(CertificationError, match="not reachable"),
         ):


### PR DESCRIPTION
## Summary
- require Populace-US certification to verify the supplemental `us_source_coverage.json` release file before writing the vendored country manifest
- document supplemental-release-file failures in the data certification guide
- add regression coverage for missing Populace-US source coverage during certification

## Context
This intentionally does not certify `populace-us-2024-f32c2e5-20260614`: that HF release still lacks a current `policyengine-us` compatibility claim, pins artifacts to an unreachable revision, and is missing `us_source_coverage.json`. I recorded that publisher-side blocker on PolicyEngine/populace#50.

## Validation
- `uv run ruff format src/policyengine/provenance/certification.py tests/test_certify_data_release.py`
- `uv run ruff check src/policyengine/provenance/certification.py tests/test_certify_data_release.py`
- `uv run python -m pytest -q tests/test_certify_data_release.py tests/test_release_manifests.py`
- `uv run python -m pytest -q tests/test_release_manifests.py tests/test_models.py tests/test_bundle_refresh.py tests/test_certify_data_release.py tests/test_pyproject_pins.py tests/test_preservation_mirror.py`
- `uv build`
- `git diff --check`
