### PR TITLE
Certify latest Populace US release

### DIFF
--- a/changelog.d/certify-us-populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z.changed.md
+++ b/changelog.d/certify-us-populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z.changed.md
@@ -1,0 +1,1 @@
+Certify the US data release `populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z` (populace_us_2024, policyengine-us 1.729.0) directly from its data release manifest.

--- a/src/policyengine/data/release_manifests/us.json
+++ b/src/policyengine/data/release_manifests/us.json
@@ -5,51 +5,51 @@
     "certified_by": "policyengine.py certification",
     "certified_for_model_version": "1.729.0",
     "compatibility_basis": "built_with_model_package",
-    "data_build_id": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z"
+    "data_build_id": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z"
   },
   "certified_data_artifact": {
-    "build_id": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
+    "build_id": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
     "data_package": {
       "name": "populace-data",
       "version": "0.1.0"
     },
     "dataset": "populace_us_2024",
-    "sha256": "b8441d5a5077ccf5533ea41eace846fced97cff8c35acd47bde1db4bd40ad469",
-    "uri": "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z"
+    "sha256": "a912aea0ca0c27bb5225516bf859d4937cad0579a2f3971d7306086bc61cbfd7",
+    "uri": "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z"
   },
   "country_id": "us",
   "data_package": {
     "name": "populace-data",
-    "release_manifest_path": "releases/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/release_manifest.json",
-    "release_manifest_revision": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
+    "release_manifest_path": "releases/populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z/release_manifest.json",
+    "release_manifest_revision": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
     "repo_id": "policyengine/populace-us",
     "repo_type": "dataset",
     "version": "0.1.0"
   },
   "datasets": {
     "calibration_diagnostics": {
-      "path": "releases/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/calibration_diagnostics.json",
+      "path": "releases/populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z/calibration_diagnostics.json",
       "repo_id": "policyengine/populace-us",
-      "revision": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
-      "sha256": "10df99c93045bc12370d3510e8b83631c8f670e29a234ef90677c004d99c63f3"
+      "revision": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
+      "sha256": "4c363816bce3decabb392c6d61002420fd60de85beec30022c3d81684765763b"
     },
     "populace_us_2024": {
       "path": "populace_us_2024.h5",
       "repo_id": "policyengine/populace-us",
-      "revision": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
-      "sha256": "b8441d5a5077ccf5533ea41eace846fced97cff8c35acd47bde1db4bd40ad469"
+      "revision": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
+      "sha256": "a912aea0ca0c27bb5225516bf859d4937cad0579a2f3971d7306086bc61cbfd7"
     },
     "populace_us_2024_calibration": {
       "path": "populace_us_2024_calibration.npz",
       "repo_id": "policyengine/populace-us",
-      "revision": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
-      "sha256": "400a427e16aad2ea5696a7fdebdb19d1834c782a0b59e628b8c8a7e6d1c1f77c"
+      "revision": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
+      "sha256": "f701d36341c5d6c39862acef14db074027bdcd289d3523571020c94892f33ccb"
     },
     "us_source_coverage": {
-      "path": "releases/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/us_source_coverage.json",
+      "path": "releases/populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z/us_source_coverage.json",
       "repo_id": "policyengine/populace-us",
-      "revision": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
-      "sha256": "7ef7dc5906e51c56301dcf1c89d2f21e94ec29d8bfffdf6b00591e5525ff68bf"
+      "revision": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
+      "sha256": "66c3749e39d324ae892b3482341468b6205d06e69140c19b7c5136f69e0cb0b3"
     }
   },
   "default_dataset": "populace_us_2024",

--- a/src/policyengine/data/release_manifests/us.trace.tro.jsonld
+++ b/src/policyengine/data/release_manifests/us.trace.tro.jsonld
@@ -17,7 +17,7 @@
         "schema:name": "PolicyEngine",
         "schema:url": "https://policyengine.org"
       },
-      "schema:dateCreated": "2026-06-15T20:46:02.532820+00:00",
+      "schema:dateCreated": "2026-06-16T13:15:11.179501+00:00",
       "schema:description": "TRACE TRO for certified runtime bundle us-4.17.3 covering the bundle manifest, the certified dataset artifact, the country model wheel, and the country data release manifest when it is available.",
       "schema:name": "policyengine us certified bundle TRO",
       "trov:createdWith": {
@@ -45,7 +45,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/data_release_manifest"
               },
-              "trov:hasLocation": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/releases/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/release_manifest.json"
+              "trov:hasLocation": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z/releases/populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z/release_manifest.json"
             },
             {
               "@id": "arrangement/1/location/dataset",
@@ -53,7 +53,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/dataset"
               },
-              "trov:hasLocation": "https://huggingface.co/policyengine/populace-us/resolve/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/populace_us_2024.h5"
+              "trov:hasLocation": "https://huggingface.co/policyengine/populace-us/resolve/populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z/populace_us_2024.h5"
             },
             {
               "@id": "arrangement/1/location/model_wheel",
@@ -75,21 +75,21 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for us",
             "trov:mimeType": "application/json",
-            "trov:sha256": "49ef8cadc5d176b92d330911a43ffe4224c07376460868f2145864cbf7269165"
+            "trov:sha256": "7725e5ea1c7320fd5e28a254795c59db6be358a98af1522f2b40ee62dfc664bf"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
             "@type": "trov:ResearchArtifact",
             "schema:name": "populace-data release manifest 0.1.0",
             "trov:mimeType": "application/json",
-            "trov:sha256": "fcad56a6deb0096ff406c8f0a1092ffa5492b11d35ddf9ba452cccff5e6a24f2"
+            "trov:sha256": "d2506e739a20ab4cdb8a709a93fb9c766e36566028e36b946e5f2f7d6714c061"
           },
           {
             "@id": "composition/1/artifact/dataset",
             "@type": "trov:ResearchArtifact",
             "schema:name": "populace_us_2024",
             "trov:mimeType": "application/x-hdf5",
-            "trov:sha256": "b8441d5a5077ccf5533ea41eace846fced97cff8c35acd47bde1db4bd40ad469"
+            "trov:sha256": "a912aea0ca0c27bb5225516bf859d4937cad0579a2f3971d7306086bc61cbfd7"
           },
           {
             "@id": "composition/1/artifact/model_wheel",
@@ -102,7 +102,7 @@
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "81745d9c5d0d8ef3580b5d2b2d78c90b7f377a192856d1e71505cf042a6a868b"
+          "trov:sha256": "254eeb7c26990cd8b58001a43c37e37fcf39de6af71186f53bb1908e13b0c9a7"
         }
       },
       "trov:hasPerformance": {
@@ -111,17 +111,14 @@
         "pe:builtWithModelVersion": "1.729.0",
         "pe:certifiedBy": "policyengine.py certification",
         "pe:certifiedForModelVersion": "1.729.0",
-        "pe:ciGitRef": "refs/heads/main",
-        "pe:ciGitSha": "54a794271713fc13b0d5cb2579384f1b960e46a2",
-        "pe:ciRunUrl": "https://github.com/PolicyEngine/policyengine.py/actions/runs/27578223029",
         "pe:compatibilityBasis": "built_with_model_package",
-        "pe:dataBuildId": "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z",
-        "pe:emittedIn": "github-actions",
-        "rdfs:comment": "Certification of build populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z for policyengine-us 1.729.0.",
+        "pe:dataBuildId": "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z",
+        "pe:emittedIn": "local",
+        "rdfs:comment": "Certification of build populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z for policyengine-us 1.729.0.",
         "trov:accessedArrangement": {
           "@id": "arrangement/1"
         },
-        "trov:startedAtTime": "2026-06-15T20:46:02.532820+00:00",
+        "trov:startedAtTime": "2026-06-16T13:15:11.179501+00:00",
         "trov:wasConductedBy": {
           "@id": "trs"
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -119,7 +119,7 @@ class TestUSModel:
         assert (
             us_latest.default_dataset_uri
             == "hf://policyengine/populace-us/populace_us_2024.h5"
-            "@populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z"
+            "@populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z"
         )
 
     def test_has_hundreds_of_parameters(self):

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -44,8 +44,8 @@ POLICYENGINE_VERSION = re.search(
 US_MODEL_VERSION = "1.729.0"
 US_BUILT_WITH_MODEL_VERSION = "1.729.0"
 US_DATA_RELEASE_VERSION = "0.1.0"
-US_DATA_RELEASE_PATH = "releases/populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z/release_manifest.json"
-US_DATA_RELEASE_REVISION = "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z"
+US_DATA_RELEASE_REVISION = "populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z"
+US_DATA_RELEASE_PATH = f"releases/{US_DATA_RELEASE_REVISION}/release_manifest.json"
 US_DATA_ARTIFACT_REVISION = US_DATA_RELEASE_REVISION
 US_CERTIFICATION_SOURCE = "policyengine.py certification"
 US_MANAGED_DATASET_URI = (
@@ -99,16 +99,10 @@ class TestReleaseManifests:
             manifest.data_package.release_manifest_revision == US_DATA_RELEASE_REVISION
         )
         assert manifest.certified_data_artifact is not None
-        assert (
-            manifest.certified_data_artifact.build_id
-            == "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z"
-        )
+        assert manifest.certified_data_artifact.build_id == US_DATA_RELEASE_REVISION
         assert manifest.certified_data_artifact.dataset == "populace_us_2024"
         assert manifest.certification is not None
-        assert (
-            manifest.certification.data_build_id
-            == "populace-us-2024-0cdbb27-c239dfe51c11-20260615T201302Z"
-        )
+        assert manifest.certification.data_build_id == US_DATA_RELEASE_REVISION
         assert manifest.certification.compatibility_basis == "built_with_model_package"
         assert (
             manifest.certification.built_with_model_version


### PR DESCRIPTION
## Summary
- certify Populace US release `populace-us-2024-f32c2e5-0c38bc47db89-20260616T124451Z` in the bundled US release manifest
- update the Populace H5, calibration NPZ, diagnostics, and source coverage hashes
- regenerate the US TRACE sidecar and update release-manifest tests to the new certified release

## Validation
- Populace release contract validated locally for the published release
- Hugging Face `policyengine/populace-us` latest pointer and tag verified against local artifact hashes
- `uv run --extra us --extra dev python -m pytest tests/test_release_manifests.py tests/test_models.py tests/test_certify_data_release.py tests/test_trace_tro.py tests/test_pyproject_pins.py -q` (132 passed, 1 LibYAML warning)
- `uv run --extra us --extra dev ruff check tests/test_models.py tests/test_release_manifests.py`
- `git diff --check`