### PR TITLE
Drop us-data package from bundle scaffold

### DIFF
--- a/changelog.d/bundle-drop-us-data-package.fixed.md
+++ b/changelog.d/bundle-drop-us-data-package.fixed.md
@@ -1,0 +1,1 @@
+Stop treating `policyengine-us-data` as an installable package in the certified bundle scaffold.

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -70,8 +70,7 @@ Run:
 python scripts/bundle.py update-packages \
   --core 3.27.0 \
   --us 1.730.0 \
-  --uk 2.91.0 \
-  --us-data 1.118.0
+  --uk 2.91.0
 ```
 
 To certify a new data release from a data-producer manifest, run:

--- a/scripts/bundle.py
+++ b/scripts/bundle.py
@@ -51,7 +51,7 @@ def _update_packages(args: argparse.Namespace) -> int:
     from prepare_package_bundle_update import main as prepare_package_bundle_update_main
 
     argv: list[str] = []
-    for option in ("core", "us", "uk", "us_data"):
+    for option in ("core", "us", "uk"):
         value = getattr(args, option)
         if value:
             argv.extend([f"--{option.replace('_', '-')}", value])
@@ -165,11 +165,6 @@ def _parser() -> argparse.ArgumentParser:
     packages.add_argument("--core", help="Exact version for policyengine-core.")
     packages.add_argument("--us", help="Exact version for policyengine-us.")
     packages.add_argument("--uk", help="Exact version for policyengine-uk.")
-    packages.add_argument(
-        "--us-data",
-        dest="us_data",
-        help="Exact version for policyengine-us-data.",
-    )
     packages.add_argument(
         "--changelog",
         default="Update the certified PolicyEngine bundle pins.",

--- a/scripts/prepare_package_bundle_update.py
+++ b/scripts/prepare_package_bundle_update.py
@@ -17,7 +17,6 @@ PACKAGE_ARGS = {
     "core": "policyengine-core",
     "us": "policyengine-us",
     "uk": "policyengine-uk",
-    "us_data": "policyengine-us-data",
 }
 
 

--- a/src/policyengine/data/bundle/manifest.json
+++ b/src/policyengine/data/bundle/manifest.json
@@ -225,16 +225,6 @@
       "name": "policyengine-us",
       "role": "country_model",
       "version": "1.729.0"
-    },
-    "policyengine-us-data": {
-      "country": "us",
-      "import_name": "policyengine_us_data",
-      "install_requirement": "policyengine-us-data==1.78.2; python_version >= '3.12' and python_version < '3.15'",
-      "markers": "python_version >= '3.12' and python_version < '3.15'",
-      "name": "policyengine-us-data",
-      "optional": true,
-      "role": "country_data",
-      "version": "1.78.2"
     }
   },
   "policyengine_version": "4.18.0",

--- a/src/policyengine/data/bundle/uk.trace.tro.jsonld
+++ b/src/policyengine/data/bundle/uk.trace.tro.jsonld
@@ -75,7 +75,7 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for uk",
             "trov:mimeType": "application/json",
-            "trov:sha256": "9b13579bebf6acfd9530bcdb62578fa84f61f06f6ffb9875b96989f7ae1661bd"
+            "trov:sha256": "4edd42f304aad4fc7699700565fca3ab4ca2ca6cd0f4516cddfdaf72347b2260"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
@@ -102,7 +102,7 @@
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "a4917b65289b9a0d1cbb68f0410e24e8d5bbab7b30075fdad4d56897f8f30ca3"
+          "trov:sha256": "662ccbe3e8e06197712799fd41b0cf831fa0ac2739be8a7efd9ed57b1e0ae96b"
         }
       },
       "trov:hasPerformance": {

--- a/src/policyengine/data/bundle/us.trace.tro.jsonld
+++ b/src/policyengine/data/bundle/us.trace.tro.jsonld
@@ -75,7 +75,7 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for us",
             "trov:mimeType": "application/json",
-            "trov:sha256": "9b13579bebf6acfd9530bcdb62578fa84f61f06f6ffb9875b96989f7ae1661bd"
+            "trov:sha256": "4edd42f304aad4fc7699700565fca3ab4ca2ca6cd0f4516cddfdaf72347b2260"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
@@ -102,7 +102,7 @@
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "1deb4adb19f9f35241a2f59af4883f78794a847056b612b31b9385b6c5642f9e"
+          "trov:sha256": "d160fd1371060653c3a225cff9e39ee481594bbf1397e41dad7882dd05b38abf"
         }
       },
       "trov:hasPerformance": {

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -49,13 +49,16 @@ def test_bundle_install_requirements_are_country_scoped():
         manifest["packages"]["policyengine-core"]["install_requirement"],
         manifest["packages"]["policyengine-uk"]["install_requirement"],
     ]
-    assert (
-        "policyengine-us-data==1.78.2; python_version >= '3.12' and python_version < '3.15'"
-        in bundle.bundle_install_requirements(
-            manifest,
-            countries=["us"],
-        )
+    us_requirements = bundle.bundle_install_requirements(
+        manifest,
+        countries=["us"],
     )
+    assert us_requirements == [
+        f"policyengine=={manifest['policyengine_version']}",
+        manifest["packages"]["policyengine-core"]["install_requirement"],
+        manifest["packages"]["policyengine-us"]["install_requirement"],
+    ]
+    assert not any("policyengine-us-data" in req for req in us_requirements)
 
 
 def test_dataset_plans_use_certified_release_metadata(tmp_path):

--- a/tests/test_bundle_metadata.py
+++ b/tests/test_bundle_metadata.py
@@ -39,6 +39,7 @@ def test_bundle_manifest_exposes_model_and_country_extras():
         "policyengine-uk",
     ]
     assert "policyengine-uk-data" not in manifest["packages"]
+    assert "policyengine-us-data" not in manifest["packages"]
 
 
 def test_bundle_manifest_carries_populace_uk_data_release():


### PR DESCRIPTION
Fixes #432

## Summary

This removes `policyengine-us-data` from the current certified bundle package scaffold now that the certified US dataset is represented through the Populace data release manifest path rather than the legacy Python data package.

Changes included:

- Remove `policyengine-us-data` from `src/policyengine/data/bundle/manifest.json` package metadata.
- Remove the `--us-data` package update input from the bundle maintenance scripts and docs.
- Update bundle tests to assert US installs only include `policyengine`, `policyengine-core`, and `policyengine-us`.
- Regenerate bundled TRACE TRO manifest and composition hashes for the updated manifest.
- Add a changelog fragment.

## Validation

- `ruff format scripts/bundle.py scripts/prepare_package_bundle_update.py tests/test_bundle.py tests/test_bundle_metadata.py`
- `ruff check scripts/bundle.py scripts/prepare_package_bundle_update.py tests/test_bundle.py tests/test_bundle_metadata.py`
- `python scripts/bundle.py check`
- `POLICYENGINE_SKIP_COUNTRY_IMPORTS=1 .venv/bin/python -m pytest tests/test_bundle.py tests/test_bundle_metadata.py`
- `python scripts/export_bundle_release_assets.py --dist-dir /tmp/policyengine-bundle-assets-check`

The exported bundle constraints now contain only `policyengine`, `policyengine-core`, `policyengine-uk`, and `policyengine-us`.