### PR TITLE
Separate PyPI and bundle release assets

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -157,20 +157,21 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Export bundle release assets
-        run: python scripts/export_bundle_release_assets.py --dist-dir dist
+        run: python scripts/export_bundle_release_assets.py --dist-dir release-assets
       - name: Verify bundle package metadata
         env:
           POLICYENGINE_SKIP_COUNTRY_IMPORTS: "1"
         run: |
           VERSION=$(python .github/fetch_version.py)
           policyengine bundle verify --country us --country uk --packages-only --json \
-            > "dist/policyengine-bundle-$VERSION.verification.json"
+            > "release-assets/policyengine-bundle-$VERSION.verification.json"
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI }}
-          skip_existing: true
+          skip-existing: true
+          packages-dir: dist
       - name: Create GitHub Release
         run: |
           VERSION=$(python .github/fetch_version.py)
@@ -178,7 +179,7 @@ jobs:
             --title "v$VERSION" \
             --notes "See [CHANGELOG.md](https://github.com/PolicyEngine/policyengine.py/blob/main/CHANGELOG.md) for details." \
             --latest \
-            "dist/policyengine-bundle-$VERSION.json" \
-            "dist/policyengine-bundle-$VERSION.constraints.txt" \
-            "dist/policyengine-bundle-$VERSION.citation.txt" \
-            "dist/policyengine-bundle-$VERSION.verification.json"
+            "release-assets/policyengine-bundle-$VERSION.json" \
+            "release-assets/policyengine-bundle-$VERSION.constraints.txt" \
+            "release-assets/policyengine-bundle-$VERSION.citation.txt" \
+            "release-assets/policyengine-bundle-$VERSION.verification.json"

--- a/changelog.d/separate-release-assets-from-pypi.fixed.md
+++ b/changelog.d/separate-release-assets-from-pypi.fixed.md
@@ -1,0 +1,1 @@
+Keep bundle release sidecar files out of the PyPI upload directory during publication.


### PR DESCRIPTION
Fixes #434

## Summary

This keeps bundle release sidecars out of the PyPI upload directory during the main-branch publish workflow.

Changes included:

- Export bundle sidecar files to `release-assets/` instead of `dist/`.
- Write the bundle verification JSON to `release-assets/`.
- Explicitly configure `pypa/gh-action-pypi-publish` with `packages-dir: dist`.
- Upload GitHub Release sidecars from `release-assets/`.
- Update the deprecated `skip_existing` PyPI action input to `skip-existing`.
- Add a changelog fragment so the next release versions on top of `4.18.1`.

## Why

The prior publish run passed bundle package metadata verification, but PyPI upload failed because `dist/` contained both Python distributions and bundle sidecar files. The PyPI action scans its package directory and rejects non-distribution files such as `policyengine-bundle-4.18.1.citation.txt`.

## Validation

- Parsed `.github/workflows/push.yaml` with Python YAML loading.
- Ran `python scripts/export_bundle_release_assets.py --dist-dir /tmp/policyengine-release-assets-check`.
- Ran `.venv/bin/python -m build --outdir /tmp/policyengine-pypi-dist-check` with network access for isolated build requirements.
- Confirmed `/tmp/policyengine-pypi-dist-check` contains only the wheel and sdist.
- Confirmed release sidecars are generated separately under `/tmp/policyengine-release-assets-check`.
- Ran `git diff --check`.

Note: a focused local pytest command was interrupted because pytest bootstrap hung while importing the full US model parameter tree in this local environment. The touched code path is workflow-only; the export script itself was run directly.