### PR TITLE
Certify Populace US CD concept budget release

### DIFF
--- a/changelog.d/certify-us-populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z.changed.md
+++ b/changelog.d/certify-us-populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z.changed.md
@@ -1,0 +1,1 @@
+Certify the US populace data release `populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z` (populace_us_2024, policyengine-us 1.745.0) into the PolicyEngine bundle manifest.

--- a/src/policyengine/data/bundle/manifest.json
+++ b/src/policyengine/data/bundle/manifest.json
@@ -97,30 +97,30 @@
       "version": "populace-uk-2023-dd68c73-4aa4b14-20260619T023711Z"
     },
     "us": {
-      "build_id": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
+      "build_id": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
       "bundle_id": "us-4.18.4",
       "certification": {
         "built_with_model_version": "1.745.0",
         "certified_by": "policyengine.py bundle certification",
         "certified_for_model_version": "1.745.0",
         "compatibility_basis": "built_with_model_package",
-        "data_build_id": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z"
+        "data_build_id": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z"
       },
       "certified_data_artifact": {
-        "build_id": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
+        "build_id": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
         "data_package": {
           "name": "populace-data",
           "version": "0.1.0"
         },
         "dataset": "populace_us_2024",
-        "sha256": "ff9df33c820bc9014ed6028f7e2a2cd91ce9315eb1c35f9412769d7bdcadb334",
-        "uri": "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z"
+        "sha256": "32fcf6b23e96d27d59cf4eca618bd21bd5a689d6099db6655e9e8d955442b41d",
+        "uri": "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z"
       },
       "country_id": "us",
       "data_package": {
         "name": "populace-data",
-        "release_manifest_path": "releases/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/release_manifest.json",
-        "release_manifest_revision": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
+        "release_manifest_path": "releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/release_manifest.json",
+        "release_manifest_revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
         "repo_id": "policyengine/populace-us",
         "repo_type": "dataset",
         "version": "0.1.0"
@@ -128,22 +128,34 @@
       "data_producer": "populace",
       "datasets": {
         "calibration_diagnostics": {
-          "path": "releases/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/calibration_diagnostics.json",
+          "path": "releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/calibration_diagnostics.json",
           "repo_id": "policyengine/populace-us",
-          "revision": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
-          "sha256": "332dc2f88de65f4c93a3a66b9a5ca6e6900135b9899fceef120c20127e6c256a"
+          "revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+          "sha256": "19610f0dea6c1b92f2efe9466d06b510be6247e1ab4e536f082a61498b775c7f"
+        },
+        "demographics": {
+          "path": "releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/demographics.json",
+          "repo_id": "policyengine/populace-us",
+          "revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+          "sha256": "394fc6c9b22a5aa804b7bd9e12e721065dcc345222fae315b9e6ac240fa21949"
         },
         "populace_us_2024": {
           "path": "populace_us_2024.h5",
           "repo_id": "policyengine/populace-us",
-          "revision": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
-          "sha256": "ff9df33c820bc9014ed6028f7e2a2cd91ce9315eb1c35f9412769d7bdcadb334"
+          "revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+          "sha256": "32fcf6b23e96d27d59cf4eca618bd21bd5a689d6099db6655e9e8d955442b41d"
         },
         "populace_us_2024_calibration": {
           "path": "populace_us_2024_calibration.npz",
           "repo_id": "policyengine/populace-us",
-          "revision": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
-          "sha256": "6d4f5662c54b4b0e26becbae6f6e63336237105e7e3c82d4e1d635aa60cf67a3"
+          "revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+          "sha256": "bdb1eb728652bc9bea9f2033201e9e241412616ce6e83e5b8c6f7c79d57b7d41"
+        },
+        "reform_validation": {
+          "path": "releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/reform_validation.json",
+          "repo_id": "policyengine/populace-us",
+          "revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+          "sha256": "f6360c3668f38dd9c3bfe600170fdaf1a9a631a0c2accc5ecab03adb7ddfd8d6"
         },
         "states/AK": {
           "path": "states/AK.h5",
@@ -452,14 +464,14 @@
           "sha256": "731d83ae37863ff994df2f953740ddb10b36910f43af01b38d36ffb55a88d4b5"
         },
         "us_source_coverage": {
-          "path": "releases/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/us_source_coverage.json",
+          "path": "releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/us_source_coverage.json",
           "repo_id": "policyengine/populace-us",
-          "revision": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
-          "sha256": "af4c465a1a5982a10d8d5404e3917b11e190b35a1da3336e606db6ee1a1740fe"
+          "revision": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+          "sha256": "094240968ce3b617ecd214525f46649b9586f6d6a66e136833d261a413553ab6"
         }
       },
       "default_dataset": "populace_us_2024",
-      "default_dataset_uri": "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
+      "default_dataset_uri": "hf://policyengine/populace-us/populace_us_2024.h5@populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
       "model_package": {
         "name": "policyengine-us",
         "sha256": "2af30b694b681adca7c2e2bd695bbeb41c03769d9ae908f82f671f8502ce32d9",
@@ -477,10 +489,10 @@
       },
       "regional_release_manifest_uri": "https://huggingface.co/policyengine/policyengine-us-data/resolve/1.115.5/releases/1.115.5/release_manifest.json",
       "regional_source_manifest_uri": "hf://model/policyengine/policyengine-us-data@1.115.5/releases/1.115.5/release_manifest.json",
-      "release_manifest_uri": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/releases/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/release_manifest.json",
+      "release_manifest_uri": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/release_manifest.json",
       "schema_version": 1,
-      "source_manifest_uri": "hf://dataset/policyengine/populace-us@populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/releases/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/release_manifest.json",
-      "version": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z"
+      "source_manifest_uri": "hf://dataset/policyengine/populace-us@populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/release_manifest.json",
+      "version": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z"
     }
   },
   "extras": {

--- a/src/policyengine/data/bundle/us.trace.tro.jsonld
+++ b/src/policyengine/data/bundle/us.trace.tro.jsonld
@@ -17,7 +17,7 @@
         "schema:name": "PolicyEngine",
         "schema:url": "https://policyengine.org"
       },
-      "schema:dateCreated": "2026-06-26T12:26:36+00:00",
+      "schema:dateCreated": "2026-06-27T04:55:05.133582+00:00",
       "schema:description": "TRACE TRO for certified runtime bundle us-4.18.4 covering the bundle manifest, the certified dataset artifact, the country model wheel, and the country data release manifest when it is available.",
       "schema:name": "policyengine us certified bundle TRO",
       "trov:createdWith": {
@@ -45,7 +45,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/data_release_manifest"
               },
-              "trov:hasLocation": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/releases/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/release_manifest.json"
+              "trov:hasLocation": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/releases/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/release_manifest.json"
             },
             {
               "@id": "arrangement/1/location/dataset",
@@ -53,7 +53,7 @@
               "trov:hasArtifact": {
                 "@id": "composition/1/artifact/dataset"
               },
-              "trov:hasLocation": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z/populace_us_2024.h5"
+              "trov:hasLocation": "https://huggingface.co/datasets/policyengine/populace-us/resolve/populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z/populace_us_2024.h5"
             },
             {
               "@id": "arrangement/1/location/model_wheel",
@@ -75,21 +75,21 @@
             "@type": "trov:ResearchArtifact",
             "schema:name": "policyengine.py bundle manifest for us",
             "trov:mimeType": "application/json",
-            "trov:sha256": "9a4ee3e810600b42725bda9e21474306ba29118d43171c93aa754d95f1132cc1"
+            "trov:sha256": "e248fb66e8e4872acccc61442868d6d1e6f11b37903ab87e3fcd3c8212fb6a8f"
           },
           {
             "@id": "composition/1/artifact/data_release_manifest",
             "@type": "trov:ResearchArtifact",
             "schema:name": "populace-data release manifest 0.1.0",
             "trov:mimeType": "application/json",
-            "trov:sha256": "c445118fdce40cbe5137957d18509c420b9e2146417a50371c461b20679f8b3f"
+            "trov:sha256": "ab08312a309f17e76299df17acef0816f300dfe4d2ca2fba7793b1b37edc3a26"
           },
           {
             "@id": "composition/1/artifact/dataset",
             "@type": "trov:ResearchArtifact",
             "schema:name": "populace_us_2024",
             "trov:mimeType": "application/x-hdf5",
-            "trov:sha256": "ff9df33c820bc9014ed6028f7e2a2cd91ce9315eb1c35f9412769d7bdcadb334"
+            "trov:sha256": "32fcf6b23e96d27d59cf4eca618bd21bd5a689d6099db6655e9e8d955442b41d"
           },
           {
             "@id": "composition/1/artifact/model_wheel",
@@ -102,7 +102,7 @@
         "trov:hasFingerprint": {
           "@id": "composition/1/fingerprint",
           "@type": "trov:CompositionFingerprint",
-          "trov:sha256": "c1ce3ae57d66a144072b2c30a635ff51af2eba8d43a2f285ce2cfbeff7f7260a"
+          "trov:sha256": "71bac8bc42dcf96814ca9e7854aff80ec64fb5602ba9b8eb001ebe7956af9533"
         }
       },
       "trov:hasPerformance": {
@@ -111,17 +111,14 @@
         "pe:builtWithModelVersion": "1.745.0",
         "pe:certifiedBy": "policyengine.py bundle certification",
         "pe:certifiedForModelVersion": "1.745.0",
-        "pe:ciGitRef": "refs/heads/main",
-        "pe:ciGitSha": "657c118c58542db7cffba9971fb221db79abb2f7",
-        "pe:ciRunUrl": "https://github.com/PolicyEngine/policyengine.py/actions/runs/28262886605",
         "pe:compatibilityBasis": "built_with_model_package",
-        "pe:dataBuildId": "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z",
-        "pe:emittedIn": "github-actions",
-        "rdfs:comment": "Certification of build populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z for policyengine-us 1.745.0.",
+        "pe:dataBuildId": "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z",
+        "pe:emittedIn": "local",
+        "rdfs:comment": "Certification of build populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z for policyengine-us 1.745.0.",
         "trov:accessedArrangement": {
           "@id": "arrangement/1"
         },
-        "trov:startedAtTime": "2026-06-26T12:26:36+00:00",
+        "trov:startedAtTime": "2026-06-27T04:55:05.133582+00:00",
         "trov:wasConductedBy": {
           "@id": "trs"
         }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -120,8 +120,8 @@ class TestUSModel:
         assert (
             us_latest.default_dataset_uri
             == "hf://policyengine/populace-us/populace_us_2024.h5"
-            "@populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-"
-            "20260626T122636Z"
+            "@populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-"
+            "20260627T022640Z"
         )
 
     def test_has_hundreds_of_parameters(self):

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -40,7 +40,7 @@ US_MODEL_VERSION = "1.745.0"
 US_BUILT_WITH_MODEL_VERSION = "1.745.0"
 US_DATA_RELEASE_VERSION = "0.1.0"
 US_DATA_RELEASE_ID = (
-    "populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-20260626T122636Z"
+    "populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z"
 )
 US_DATA_RELEASE_REVISION = US_DATA_RELEASE_ID
 US_DATA_RELEASE_PATH = f"releases/{US_DATA_RELEASE_ID}/release_manifest.json"

--- a/tests/test_us_regions.py
+++ b/tests/test_us_regions.py
@@ -107,8 +107,8 @@ class TestUSRegionRegistry:
         assert national.region_type == "national"
         assert national.dataset_path == (
             "hf://policyengine/populace-us/populace_us_2024.h5"
-            "@populace-us-2024-formula-owned-fix-a56aefd-capgains-b2500-"
-            "20260626T122636Z"
+            "@populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-"
+            "20260627T022640Z"
         )
 
     def test__given_us_registry__then_has_51_states(self):


### PR DESCRIPTION
## Summary\n- Certifies Populace US release `populace-us-2024-cd-concept-budget-dbbdcec-512e-b2500-r2-20260627T022640Z` into the PolicyEngine bundle manifest.\n- Points the default US dataset at the published H5 sha256 `32fcf6b23e96d27d59cf4eca618bd21bd5a689d6099db6655e9e8d955442b41d`.\n- Preserves existing state regional artifacts from `policyengine-us-data@1.115.5` until Populace ships replacement state artifacts.\n- Updates US TRACE TRO and release-id test expectations.\n\n## Validation\n- `uv run python scripts/bundle.py check`\n- `uv run --extra dev ruff check scripts src tests/test_release_manifests.py tests/test_models.py tests/test_us_regions.py`\n- `uv run --extra dev python -m pytest tests/test_release_manifests.py tests/test_bundle.py tests/test_us_regions.py tests/test_models.py -q` (107 passed)\n\n## Populace release audit\n- Candidate common-surface loss: 0.053957080041720416\n- Incumbent common-surface loss: 0.09138438112503779\n- Candidate within 10%: 0.7686491202559256\n- Incumbent within 10%: 0.5841209829867675\n- Target surface: 6,877 targets with matching hashes against the incumbent score\n