### PR TITLE
Update US surface snapshot for small Populace default

### DIFF
--- a/changelog.d/us-small-populace-snapshot.fixed.md
+++ b/changelog.d/us-small-populace-snapshot.fixed.md
@@ -1,0 +1,1 @@
+Update the US model surface snapshot for the smaller default Populace bundle.

--- a/tests/fixtures/household_calculator_snapshots/us_model_surface.json
+++ b/tests/fixtures/household_calculator_snapshots/us_model_surface.json
@@ -5,7 +5,7 @@
   "has_income_tax": true,
   "has_region_registry": true,
   "model_package_name": "policyengine-us",
-  "num_parameters_bucketed_100s": 956,
-  "num_variables_bucketed_100s": 55,
+  "num_parameters_bucketed_100s": 917,
+  "num_variables_bucketed_100s": 54,
   "region_registry_country": "us"
 }


### PR DESCRIPTION
## Summary
- updates the US household calculator surface snapshot for the smaller default Populace bundle merged in #443
- adds the changelog fragment needed for the release workflow to proceed

## Validation
- uv run ruff format --check .
- uv run ruff check .
- git diff --check
- uv run --extra models pytest tests/test_household_calculator_snapshot.py -q
- uv run --extra models pytest tests/test_bundle.py tests/test_release_manifests.py tests/test_models.py tests/test_us_regions.py tests/test_certify_data_release.py -q