### PR TITLE
Add wrapper regression test for local dataset paths

### DIFF
--- a/changelog.d/415.fixed.md
+++ b/changelog.d/415.fixed.md
@@ -1,0 +1,1 @@
+Add a full-wrapper regression test covering `managed_microsimulation` with a plain local dataset path and `allow_unmanaged=True` (the #415 scenario, resolved by #442).

--- a/tests/test_release_manifests.py
+++ b/tests/test_release_manifests.py
@@ -912,6 +912,41 @@ class TestReleaseManifests:
             "/tmp/cps_2023.h5"
         )
 
+    def test__given_us_unmanaged_local_path__then_dataset_reaches_microsimulation(
+        self, tmp_path
+    ):
+        dataset_path = tmp_path / "local_build_2100.h5"
+        dataset_path.write_bytes(b"not a real h5; source plumbing only")
+
+        mock_microsimulation = MagicMock()
+        with (
+            patch.dict(
+                sys.modules,
+                _country_modules_with_microsimulation(
+                    "policyengine_us",
+                    mock_microsimulation,
+                ),
+            ),
+            patch(
+                "policyengine.tax_benefit_models.common.model_version.certify_data_release_compatibility",
+                return_value=get_release_manifest("us").certification,
+            ),
+        ):
+            us_model = importlib.import_module(
+                "policyengine.tax_benefit_models.us.model"
+            )
+            microsim = us_model.managed_microsimulation(
+                dataset=str(dataset_path),
+                allow_unmanaged=True,
+            )
+
+        assert mock_microsimulation.call_args.kwargs["dataset"] == str(dataset_path)
+        assert microsim.policyengine_bundle["runtime_dataset"] == "local_build_2100"
+        assert microsim.policyengine_bundle["runtime_dataset_uri"] == str(dataset_path)
+        assert microsim.policyengine_bundle["runtime_dataset_source"] == str(
+            dataset_path
+        )
+
     def test__given_uk_managed_dataset_name__then_resolves_within_bundle(self):
         mock_microsimulation = MagicMock()
         with (

--- a/uv.lock
+++ b/uv.lock
@@ -2820,7 +2820,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.18.7"
+version = "4.18.10"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Fixes #415

Test-only. #415 was closed today as resolved by #442, verified end-to-end — but main had no full-wrapper regression test for the local-path case (the resolver is tested directly, and the wrapper is tested for the default dataset and an unmanaged URI, not a plain local path). This ports the one unique test from closed #361, adapted to main's mocked-country-module harness and main's expanduser-not-resolve path semantics: `managed_microsimulation(dataset=<local path>, allow_unmanaged=True)` passes the path through to `Microsimulation` unchanged and records `runtime_dataset`/`runtime_dataset_uri`/`runtime_dataset_source` in the provenance bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)