### PR TITLE
Point release consumer dispatch at renamed policyengine-sim-api

### DIFF
--- a/.github/dispatch-policyengine-release.sh
+++ b/.github/dispatch-policyengine-release.sh
@@ -17,7 +17,7 @@ fi
 
 CONSUMER_REPOS=(
   policyengine-api
-  policyengine-api-v2
+  policyengine-sim-api
 )
 
 for repo in "${CONSUMER_REPOS[@]}"; do

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -211,7 +211,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: PolicyEngine
-          repositories: policyengine-api,policyengine-api-v2
+          repositories: policyengine-api,policyengine-sim-api
       - name: Dispatch policyengine-release to consumer repos
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/changelog.d/466.fixed.md
+++ b/changelog.d/466.fixed.md
@@ -1,0 +1,1 @@
+Point the post-release consumer dispatch at the renamed `policyengine-sim-api` repository (formerly `policyengine-api-v2`). The stale name made `create-github-app-token` fail with a 422 ("repository does not exist or is not accessible"), so the `Open consumer update PRs` job died before dispatching `policyengine-release` and no downstream version-bump PRs were opened.


### PR DESCRIPTION
Fixes #466

## Summary

The consumer repo `policyengine-api-v2` was renamed to `policyengine-sim-api`, which broke the post-release consumer-notification step in the release pipeline.

## Root cause

`NotifyConsumers` (`.github/workflows/push.yaml`) mints a GitHub App token scoped to `repositories: policyengine-api,policyengine-api-v2`, then runs `.github/dispatch-policyengine-release.sh` to send a `policyengine-release` repository dispatch to those repos. `actions/create-github-app-token` (the installation access-token API) does **not** follow repository renames, so requesting the old name returns:

```
422 — There is at least one repository that does not exist or is not accessible to the parent installation.
```

The job dies at token generation, before any dispatch. Confirmed on the `policyengine 4.20.2` release (run 29043618022): **Publish succeeded**, but **Open consumer update PRs failed**, so no downstream repo received a version-bump PR.

## Change

- `push.yaml` → `repositories: policyengine-api,policyengine-sim-api`
- `dispatch-policyengine-release.sh` → `CONSUMER_REPOS` uses `policyengine-sim-api`

The historical `CHANGELOG.md` entry that mentions the old name is intentionally left unchanged as shipped-release history.

## Note

This fixes releases **going forward**. It does not retroactively notify consumers for 4.20.2 (that dispatch already failed) — the sim API can be bumped to 4.20.2 now by manually running its `check-policyengine-updates.yml` (`workflow_dispatch`, version `4.20.2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
