### PR TITLE
Derive UK person and benunit weights when loading a dataset

### DIFF
--- a/changelog.d/478.fixed.md
+++ b/changelog.d/478.fixed.md
@@ -1,0 +1,1 @@
+Derived `person_weight` and `benunit_weight` from `household_weight` when loading a UK dataset that does not already carry them, so a directly-supplied `PolicyEngineUKDataset` filepath no longer raises `KeyError: 'person_weight'`.

--- a/src/policyengine/tax_benefit_models/uk/datasets.py
+++ b/src/policyengine/tax_benefit_models/uk/datasets.py
@@ -13,6 +13,82 @@ from policyengine.provenance.manifest import (
 )
 
 
+def _require_columns(frame: pd.DataFrame, columns: list[str], context: str) -> None:
+    """Raise a clear error when join columns needed for weight derivation are absent."""
+    missing = [column for column in columns if column not in frame.columns]
+    if missing:
+        raise KeyError(
+            f"Cannot derive weights for {context}: the {context} frame is "
+            f"missing required column(s) {missing}. UK microdata carries only "
+            "`household_weight`, so person and benunit weights are derived by "
+            "joining on household identifiers."
+        )
+
+
+def derive_person_weight(
+    person_df: pd.DataFrame, household_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Return ``person_df`` with a ``person_weight`` column.
+
+    Published UK microdata carries only ``household_weight`` at the household
+    level, so a person's weight is the weight of their household. If
+    ``person_weight`` is already present the frame is returned unchanged.
+    """
+    if "person_weight" in person_df.columns:
+        return person_df
+
+    _require_columns(person_df, ["person_household_id"], "person")
+    _require_columns(household_df, ["household_id", "household_weight"], "household")
+
+    person_df = person_df.merge(
+        household_df[["household_id", "household_weight"]],
+        left_on="person_household_id",
+        right_on="household_id",
+        how="left",
+    )
+    person_df = person_df.rename(columns={"household_weight": "person_weight"})
+    return person_df.drop(columns=["household_id"])
+
+
+def derive_benunit_weight(
+    benunit_df: pd.DataFrame,
+    person_df: pd.DataFrame,
+    household_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Return ``benunit_df`` with a ``benunit_weight`` column.
+
+    Benefit units map to households via the person frame. If ``benunit_weight``
+    is already present the frame is returned unchanged.
+    """
+    if "benunit_weight" in benunit_df.columns:
+        return benunit_df
+
+    _require_columns(benunit_df, ["benunit_id"], "benunit")
+    _require_columns(person_df, ["person_benunit_id", "person_household_id"], "person")
+    _require_columns(household_df, ["household_id", "household_weight"], "household")
+
+    benunit_household_map = person_df[
+        ["person_benunit_id", "person_household_id"]
+    ].drop_duplicates()
+    benunit_df = benunit_df.merge(
+        benunit_household_map,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    )
+    benunit_df = benunit_df.merge(
+        household_df[["household_id", "household_weight"]],
+        left_on="person_household_id",
+        right_on="household_id",
+        how="left",
+    )
+    benunit_df = benunit_df.rename(columns={"household_weight": "benunit_weight"})
+    return benunit_df.drop(
+        columns=["person_benunit_id", "person_household_id", "household_id"],
+        errors="ignore",
+    )
+
+
 class UKYearData(YearData):
     """Entity-level data for a single year."""
 
@@ -94,13 +170,21 @@ class PolicyEngineUKDataset(Dataset):
         """Load dataset from HDF5 file into this instance."""
         filepath = self.filepath
         with pd.HDFStore(filepath, mode="r") as store:
-            self.data = UKYearData(
-                person=MicroDataFrame(store["person"], weights="person_weight"),
-                benunit=MicroDataFrame(store["benunit"], weights="benunit_weight"),
-                household=MicroDataFrame(
-                    store["household"], weights="household_weight"
-                ),
-            )
+            person_df = store["person"]
+            benunit_df = store["benunit"]
+            household_df = store["household"]
+
+        # Published UK microdata carries only `household_weight`; derive the
+        # person and benunit weights when the file does not already have them,
+        # so a directly-supplied dataset behaves like a manifest-resolved one.
+        benunit_df = derive_benunit_weight(benunit_df, person_df, household_df)
+        person_df = derive_person_weight(person_df, household_df)
+
+        self.data = UKYearData(
+            person=MicroDataFrame(person_df, weights="person_weight"),
+            benunit=MicroDataFrame(benunit_df, weights="benunit_weight"),
+            household=MicroDataFrame(household_df, weights="household_weight"),
+        )
 
     def __repr__(self) -> str:
         if self.data is None:
@@ -136,42 +220,8 @@ def create_datasets(
             household_df = pd.DataFrame(year_dataset.household)
 
             # Map household weights to person and benunit levels
-            person_df = person_df.merge(
-                household_df[["household_id", "household_weight"]],
-                left_on="person_household_id",
-                right_on="household_id",
-                how="left",
-            )
-            person_df = person_df.rename(columns={"household_weight": "person_weight"})
-            person_df = person_df.drop(columns=["household_id"])
-
-            # Get household_id for each benunit from person table
-            benunit_household_map = person_df[
-                ["person_benunit_id", "person_household_id"]
-            ].drop_duplicates()
-            benunit_df = benunit_df.merge(
-                benunit_household_map,
-                left_on="benunit_id",
-                right_on="person_benunit_id",
-                how="left",
-            )
-            benunit_df = benunit_df.merge(
-                household_df[["household_id", "household_weight"]],
-                left_on="person_household_id",
-                right_on="household_id",
-                how="left",
-            )
-            benunit_df = benunit_df.rename(
-                columns={"household_weight": "benunit_weight"}
-            )
-            benunit_df = benunit_df.drop(
-                columns=[
-                    "person_benunit_id",
-                    "person_household_id",
-                    "household_id",
-                ],
-                errors="ignore",
-            )
+            benunit_df = derive_benunit_weight(benunit_df, person_df, household_df)
+            person_df = derive_person_weight(person_df, household_df)
 
             uk_dataset = PolicyEngineUKDataset(
                 id=f"{dataset_stem}_year_{year}",

--- a/tests/test_uk_dataset_weights.py
+++ b/tests/test_uk_dataset_weights.py
@@ -1,0 +1,181 @@
+"""Tests for UK dataset person/benunit weight derivation.
+
+Published UK microdata carries only `household_weight`. Person and benunit
+weights are derived from it, both when a dataset is built through
+`create_datasets` and when a caller supplies a filepath directly.
+"""
+
+import pandas as pd
+import pytest
+
+from policyengine.tax_benefit_models.uk.datasets import (
+    PolicyEngineUKDataset,
+    derive_benunit_weight,
+    derive_person_weight,
+)
+
+
+@pytest.fixture
+def frames() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Minimal UK-shaped frames carrying only `household_weight`."""
+    household = pd.DataFrame(
+        {
+            "household_id": [1, 2],
+            "household_weight": [10.0, 20.0],
+        }
+    )
+    person = pd.DataFrame(
+        {
+            "person_id": [1, 2, 3],
+            "person_benunit_id": [11, 11, 12],
+            "person_household_id": [1, 1, 2],
+        }
+    )
+    benunit = pd.DataFrame({"benunit_id": [11, 12]})
+    return person, benunit, household
+
+
+def test_derive_person_weight_when_missing(frames):
+    person, _, household = frames
+
+    result = derive_person_weight(person, household)
+
+    assert result["person_weight"].tolist() == [10.0, 10.0, 20.0]
+    assert "household_id" not in result.columns
+
+
+def test_derive_benunit_weight_when_missing(frames):
+    person, benunit, household = frames
+
+    result = derive_benunit_weight(benunit, person, household)
+
+    assert result["benunit_weight"].tolist() == [10.0, 20.0]
+    assert "person_household_id" not in result.columns
+
+
+def test_derive_person_weight_is_a_no_op_when_present(frames):
+    person, _, household = frames
+    person = person.assign(person_weight=[1.0, 2.0, 3.0])
+
+    result = derive_person_weight(person, household)
+
+    assert result is person
+    assert result["person_weight"].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_derive_benunit_weight_is_a_no_op_when_present(frames):
+    person, benunit, household = frames
+    benunit = benunit.assign(benunit_weight=[5.0, 6.0])
+
+    result = derive_benunit_weight(benunit, person, household)
+
+    assert result is benunit
+    assert result["benunit_weight"].tolist() == [5.0, 6.0]
+
+
+def test_derive_person_weight_reports_missing_join_column(frames):
+    person, _, household = frames
+
+    with pytest.raises(KeyError, match="person_household_id"):
+        derive_person_weight(person.drop(columns=["person_household_id"]), household)
+
+
+def test_derive_weights_report_missing_household_weight(frames):
+    person, benunit, household = frames
+    household = household.drop(columns=["household_weight"])
+
+    with pytest.raises(KeyError, match="household_weight"):
+        derive_person_weight(person, household)
+    with pytest.raises(KeyError, match="household_weight"):
+        derive_benunit_weight(benunit, person, household)
+
+
+def test_load_derives_weights_for_a_directly_supplied_dataset(tmp_path, frames):
+    """A dataset file with only `household_weight` loads without a KeyError.
+
+    This is the regression: published UK datasets (e.g. an Enhanced FRS
+    release) have no `person_weight` column, so constructing
+    `PolicyEngineUKDataset(filepath=...)` used to raise `KeyError`.
+    """
+    person, benunit, household = frames
+    filepath = tmp_path / "uk.h5"
+    with pd.HDFStore(filepath, mode="w") as store:
+        store.put("person", person, format="table")
+        store.put("benunit", benunit, format="table")
+        store.put("household", household, format="table")
+
+    dataset = PolicyEngineUKDataset(
+        name="uk",
+        description="uk",
+        filepath=str(filepath),
+        year=2024,
+    )
+
+    assert dataset.data.person["person_weight"].tolist() == [10.0, 10.0, 20.0]
+    assert dataset.data.benunit["benunit_weight"].tolist() == [10.0, 20.0]
+    assert dataset.data.household["household_weight"].tolist() == [10.0, 20.0]
+
+
+def test_load_preserves_existing_person_weights(tmp_path, frames):
+    """A dataset carrying its own person-level weights is not overwritten."""
+    person, benunit, household = frames
+    person = person.assign(person_weight=[1.0, 2.0, 3.0])
+    benunit = benunit.assign(benunit_weight=[5.0, 6.0])
+    filepath = tmp_path / "uk.h5"
+    with pd.HDFStore(filepath, mode="w") as store:
+        store.put("person", person, format="table")
+        store.put("benunit", benunit, format="table")
+        store.put("household", household, format="table")
+
+    dataset = PolicyEngineUKDataset(
+        name="uk",
+        description="uk",
+        filepath=str(filepath),
+        year=2024,
+    )
+
+    assert dataset.data.person["person_weight"].tolist() == [1.0, 2.0, 3.0]
+    assert dataset.data.benunit["benunit_weight"].tolist() == [5.0, 6.0]
+
+
+def test_derivation_matches_the_create_datasets_merge(frames):
+    """The shared helpers reproduce the merge `create_datasets` used inline."""
+    person, benunit, household = frames
+
+    expected_person = person.merge(
+        household[["household_id", "household_weight"]],
+        left_on="person_household_id",
+        right_on="household_id",
+        how="left",
+    )
+    expected_person = expected_person.rename(
+        columns={"household_weight": "person_weight"}
+    ).drop(columns=["household_id"])
+
+    benunit_household_map = expected_person[
+        ["person_benunit_id", "person_household_id"]
+    ].drop_duplicates()
+    expected_benunit = benunit.merge(
+        benunit_household_map,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    ).merge(
+        household[["household_id", "household_weight"]],
+        left_on="person_household_id",
+        right_on="household_id",
+        how="left",
+    )
+    expected_benunit = expected_benunit.rename(
+        columns={"household_weight": "benunit_weight"}
+    ).drop(
+        columns=["person_benunit_id", "person_household_id", "household_id"],
+        errors="ignore",
+    )
+
+    pd.testing.assert_frame_equal(
+        derive_person_weight(person, household), expected_person
+    )
+    pd.testing.assert_frame_equal(
+        derive_benunit_weight(benunit, person, household), expected_benunit
+    )


### PR DESCRIPTION
Fixes #478

## The failure

Constructing a `PolicyEngineUKDataset` against any real published UK dataset file raises `KeyError: 'person_weight'` at construction time:

```python
import policyengine as pe
from policyengine.tax_benefit_models.uk.model import PolicyEngineUKDataset

P = ".../policyengine_uk_data/storage/enhanced_frs_2024_25.h5"
ds = PolicyEngineUKDataset(name="x", description="x", filepath=P, year=2024)
sim = pe.Simulation(id="t", dataset=ds, tax_benefit_model_version=pe.uk.model,
                    extra_variables={"person": ["capital_gains"]})
sim.ensure()   # -> KeyError: 'person_weight'
```

## Why

`PolicyEngineUKDataset.load()` assumed `person_weight` and `benunit_weight` were already columns in the file. **Published UK microdata carries only `household_weight`, at the household level** — person and benunit weights are derived from it. Verified absent in `enhanced_frs_2024_25.h5`, `enhanced_frs_2023_24.h5`, and the certified `populace_uk_2023.h5`.

`create_datasets` already did that derivation inline (merging `household_weight` onto the person frame via `person_household_id`, and onto benunits via the person frame) and saved the rewritten file. So a manifest-resolved dataset worked while a directly-supplied filepath did not.

## The change

- Factored the derivation out of `create_datasets` into shared `derive_person_weight` / `derive_benunit_weight` helpers, and call them from `load()` too, so the two paths cannot drift.
- Derivation happens **only when the column is absent** — a dataset carrying its own person-level weights is returned untouched.
- Missing join columns now raise a clear, explanatory error rather than a bare `KeyError`.

**The manifest path is unchanged.** `create_datasets` performs exactly the same merges, in the same order, producing the same columns and values — verified below against the pre-change code.

## User-facing benefit

Callers can run policyengine.py on their own UK dataset — for example a newer Enhanced FRS release — without waiting for it to appear in the certified bundle manifest.

## Verification

Reproduced the `KeyError` on `main`, then on this branch, against `enhanced_frs_2024_25.h5`:

```
person_weight equal:  True
benunit_weight equal: True
person cols equal: True   benunit cols equal: True
sample weights: [2106.553  365.01886  383.83633  2106.553]   nan count: 0
```

(`equal` compares against the exact merge code `create_datasets` used before this change — the value-equivalence check, not just "it no longer raises".)

End-to-end `sim.ensure()` from the report now succeeds on both `enhanced_frs_2024_25.h5` and `enhanced_frs_2023_24.h5`.

## Tests

New `tests/test_uk_dataset_weights.py` (9 tests) covers derivation when columns are missing, no-op when present (both helper-level and through `load()`), clear errors for missing join columns, and equivalence with the original `create_datasets` merge.

Full suite: **747 passed**.