### PR TITLE
Sync uv.lock with the 4.22.0 pyproject version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2820,7 +2820,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.20.1"
+version = "4.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Main's `uv.lock` pins `policyengine 4.20.1` while `pyproject.toml` says 4.22.0 — every `uv run` regenerates the one-line delta and dirties the tree (it kept sneaking into unrelated diffs during the Build N certification; deliberately excluded there). One-line lock sync, no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)